### PR TITLE
Refactor EvCharging schema

### DIFF
--- a/schema/EvChargingOffer/v1/README.md
+++ b/schema/EvChargingOffer/v1/README.md
@@ -6,16 +6,15 @@ Attach these schemas as follows:
 
 | **Attribute Schema** | **Attach To** | **Purpose** |
 | --- | --- | --- |
-| ChargingOffer | Offer.attributes | Tariff details beyond core price fields – e.g., eligibleQuantity, idle fee policies, buyer-finder fees, and offer-specific rules. |
+| ChargingOffer | Offer.attributes | Tariff details beyond core price fields – e.g., eligibleQuantity, idle fee policies and offer-specific rules. |
 | --- | --- | --- |
 
 ## **🧭 Role and Design**
 
 - **Aligned with Beckn Core**
   Uses canonical Beckn schemas for common objects and reuses canonical components from:
-  - core.yaml – Catalog, Item, Offer, Provider, Attributes, Location, Address, GeoJSONGeometry
-  - discover.yaml – Discovery API endpoints and request/response schemas
-  - transaction.yaml – Transaction API endpoints and Order, Fulfillment, Payment schemas
+  - [core.yaml](../../core/v2/attributes.yaml) - Catalog, Item, Offer, Provider, Attributes, Location, Address, GeoJSONGeometry
+  - [api/beckn.yaml](../../../api/beckn.yaml) - Unified API specification for discovery and transaction endpoints
 - **Adds EV semantics only**
   Introduces domain-specific elements such as per-kWh/time pricing models and idle fee policies.
 - **Designed for interoperability**
@@ -48,7 +47,4 @@ This supports both local development and public hosting.
 | --- | --- |
 
 ## 🏷️ Tags
-`ev-charging, charging-offer, tariffs, pricing, idle-fee, buyer-finder-fee, beckn, json-ld, schema.org, openapi`
-
-
-
+`ev-charging, charging-offer, tariffs, pricing, idle-fee, beckn, json-ld, schema.org, openapi`

--- a/schema/EvChargingOffer/v1/attributes.yaml
+++ b/schema/EvChargingOffer/v1/attributes.yaml
@@ -7,7 +7,7 @@ info:
     Attribute schemas for charging offers (Offer.attributes).
     These attributes are attached to Offer.attributes to provide tariff details beyond 
     core price fields including per-kWh or time-based pricing, idle fee policies, 
-    buyer-finder fees, and accepted payment methods.
+    and accepted payment methods.
 
 components:
   schemas:
@@ -17,7 +17,6 @@ components:
     ChargingOffer:
       type: object
       additionalProperties: false
-      required: [priceSpecification]
       x-jsonld:
         "@context": ./context.jsonld
         "@type": ChargingOffer
@@ -30,26 +29,16 @@ components:
           example: "PER_KWH"
           x-jsonld: { "@id": tariffModel }
 
-        buyerFinderFee:
-          type: object
-          description: Commission payable by provider to the BAP for this offer.
-          x-jsonld: { "@id": buyerFinderFee }
-          additionalProperties: false
-          properties:
-            feeType:
-              type: string
-              enum: [PERCENTAGE, AMOUNT]
-              example: "PERCENTAGE"
-              x-jsonld: { "@id": feeType }
-            feeValue:
-              type: number
-              minimum: 0
-              example: 2.5
-              x-jsonld: { "@id": feeValue }
-
         idleFeePolicy:
-          type: string
-          description: Human-readable policy for post-charge idle fees.
-          example: "₹2/min after 10 min post-charge"
-          x-jsonld: { "@id": idleFeePolicy }
-
+          allOf:
+            - $ref: "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/attributes.yaml#/components/schemas/PriceSpecification"
+            - type: object
+              description: Idle fee policy specification (reuses Beckn PriceSpecification).
+              x-jsonld: { "@id": idleFeePolicy }
+          example:
+            currency: "INR"
+            value: 2
+            applicableQuantity:
+              unitCode: "MIN"
+              unitText: "minutes"
+              unitQuantity: 10

--- a/schema/EvChargingOffer/v1/context.jsonld
+++ b/schema/EvChargingOffer/v1/context.jsonld
@@ -20,23 +20,13 @@
       "@id": "beckn:tariffModel",
       "@type": "@id"
     },
-    "buyerFinderFee": "beckn:buyerFinderFee",
-    "feeType": {
-      "@id": "beckn:feeType",
-      "@type": "@id"
-    },
-    "feeValue": "beckn:feeValue",
     "idleFeePolicy": "beckn:idleFeePolicy",
 
     "PER_KWH": "beckn:TariffModelPerKwh",
     "PER_MINUTE": "beckn:TariffModelPerMinute",
     "SUBSCRIPTION": "beckn:TariffModelSubscription",
-    "TIME_OF_DAY": "beckn:TariffModelTimeOfDay",
-
-    "PERCENTAGE": "beckn:FeeTypePercentage",
-    "AMOUNT": "beckn:FeeTypeAmount"
+    "TIME_OF_DAY": "beckn:TariffModelTimeOfDay"
   },
 
   "@graph": []
 }
-

--- a/schema/EvChargingOffer/v1/vocab.jsonld
+++ b/schema/EvChargingOffer/v1/vocab.jsonld
@@ -26,33 +26,9 @@
       "@id": "beckn:idleFeePolicy",
       "@type": "rdf:Property",
       "rdfs:label": "Idle fee policy",
-      "rdfs:comment": "Human-readable policy for post-charge idle fees associated with an offer.",
-      "rdfs:domain": "beckn:ChargingOffer",
-      "schema:rangeIncludes": "schema:Text"
-    },
-    {
-      "@id": "beckn:buyerFinderFee",
-      "@type": "rdf:Property",
-      "rdfs:label": "Buyer finder fee",
-      "rdfs:comment": "Commission payable (percentage or absolute) associated with an offer/order.",
+      "rdfs:comment": "Idle fee policy specification for post-charge idle fees associated with an offer (reuses Beckn PriceSpecification).",
       "rdfs:domain": "beckn:ChargingOffer",
       "schema:rangeIncludes": "schema:PriceSpecification"
-    },
-    {
-      "@id": "beckn:feeType",
-      "@type": "rdf:Property",
-      "rdfs:label": "Fee type",
-      "rdfs:comment": "Fee type (PERCENTAGE or AMOUNT) for buyer finder fee.",
-      "rdfs:domain": "beckn:ChargingOffer",
-      "schema:rangeIncludes": "beckn:FeeType"
-    },
-    {
-      "@id": "beckn:feeValue",
-      "@type": "rdf:Property",
-      "rdfs:label": "Fee value",
-      "rdfs:comment": "Numeric fee value (interpreted per fee type).",
-      "rdfs:domain": "beckn:ChargingOffer",
-      "schema:rangeIncludes": "schema:Number"
     },
     {
       "@id": "beckn:TariffModel",
@@ -112,39 +88,6 @@
       "schema:name": "TIME_OF_DAY",
       "schema:identifier": "TIME_OF_DAY",
       "schema:alternateName": "TIME-OF-DAY"
-    },
-    {
-      "@id": "beckn:FeeType",
-      "@type": "schema:Enumeration",
-      "schema:name": "Fee Type",
-      "rdfs:comment": "Enumeration of fee types for buyer finder fee calculations.",
-      "schema:hasEnumerationMember": [
-        {
-          "@id": "beckn:FeeTypePercentage"
-        },
-        {
-          "@id": "beckn:FeeTypeAmount"
-        }
-      ]
-    },
-    {
-      "@id": "beckn:FeeTypePercentage",
-      "@type": [
-        "beckn:FeeType",
-        "schema:Enumeration"
-      ],
-      "schema:name": "PERCENTAGE",
-      "schema:identifier": "PERCENTAGE"
-    },
-    {
-      "@id": "beckn:FeeTypeAmount",
-      "@type": [
-        "beckn:FeeType",
-        "schema:Enumeration"
-      ],
-      "schema:name": "AMOUNT",
-      "schema:identifier": "AMOUNT"
     }
   ]
 }
-

--- a/schema/EvChargingPointOperator/v1/README.md
+++ b/schema/EvChargingPointOperator/v1/README.md
@@ -13,9 +13,8 @@ Attach these schemas as follows:
 
 - **Aligned with Beckn Core**
   Uses canonical Beckn schemas for common objects and reuses canonical components from:
-  - core.yaml – Catalog, Item, Offer, Provider, Attributes, Location, Address, GeoJSONGeometry
-  - discover.yaml – Discovery API endpoints and request/response schemas
-  - transaction.yaml – Transaction API endpoints and Order, Fulfillment, Payment schemas
+  - [core.yaml](../../core/v2/attributes.yaml) - Catalog, Item, Offer, Provider, Attributes, Location, Address, GeoJSONGeometry
+  - [api/beckn.yaml](../../../api/beckn.yaml) - Unified API specification for discovery and transaction endpoints
 - **Adds EV semantics only**
   Introduces operator-specific elements such as operator IDs, roaming network IDs, and support contacts.
 - **Designed for interoperability**
@@ -49,6 +48,3 @@ This supports both local development and public hosting.
 
 ## 🏷️ Tags
 `ev-charging, charging-point-operator, provider, operator, roaming, registry, beckn, json-ld, schema.org, openapi`
-
-
-

--- a/schema/EvChargingService/v1/README.md
+++ b/schema/EvChargingService/v1/README.md
@@ -20,11 +20,10 @@ Attach these schemas as follows:
 
 ## **🧭 Role and Design**
 
-- **Aligned with Beckn Core  
-    **Uses canonical Beckn schemas for common objects and reuses canonical components from:
-  - [core.yaml](../../core/v2/core.yaml) - Catalog, Item, Offer, Provider, Attributes, Location, Address, GeoJSONGeometry
-  - [discover.yaml](../../../api-specs/discover.yaml) - Discovery API endpoints and request/response schemas
-  - [transaction.yaml](../../../api-specs/transaction.yaml) - Transaction API endpoints and Order, Fulfillment, Payment schemas
+- **Aligned with Beckn Core**
+  Uses canonical Beckn schemas for common objects and reuses canonical components from:
+  - [core.yaml](../../core/v2/attributes.yaml) - Catalog, Item, Offer, Provider, Attributes, Location, Address, GeoJSONGeometry
+  - [api/beckn.yaml](../../../api/beckn.yaml) - Unified API specification for discovery and transaction endpoints
 - **Adds EV semantics only  
     **Introduces domain-specific elements such as connectors, power ratings, roaming networks, charging periods, and session telemetry.
 - **Designed for interoperability  

--- a/schema/EvChargingService/v1/attributes.yaml
+++ b/schema/EvChargingService/v1/attributes.yaml
@@ -27,11 +27,16 @@ components:
       required:
         - connectorType
         - maxPowerKW
-        - socketCount
       x-jsonld:
         "@context": ./context.jsonld
         "@type": ChargingService
       properties:
+
+        evseId:
+          type: string
+          description: EVSE identifier (e.g., OCPI/Hubject style).
+          example: "IN*ECO*01*CCS2*A"
+          x-jsonld: { "@id": evseId }
 
         # EV-specific technicals
         connectorType:
@@ -57,37 +62,53 @@ components:
           example: 5
           x-jsonld: { "@id": minPowerKW }
 
-        socketCount:
-          type: integer
-          minimum: 1
-          description: Number of simultaneously usable outlets for this connector type.
-          example: 2
-          x-jsonld: { "@id": socketCount }
-
         reservationSupported:
           type: boolean
           default: true
           description: Whether advance reservations are supported.
           x-jsonld: { "@id": reservationSupported }
 
-        # Location: REUSE Beckn Location (core.yaml) via $ref
-        serviceLocation:
-          allOf:
-            - $ref: "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/core.yaml#/components/schemas/Location"
-            - type: object
-              description: Location of the charging site (reuses Beckn Location).
-              x-jsonld: { "@id": serviceLocation }
+        # Charging Station: Object containing station ID and location
+        chargingStation:
+          type: object
+          description: Charging station information including station ID and location.
+          x-jsonld: { "@id": chargingStation }
+          properties:
+            id:
+              type: string
+              description: Unique identifier for the charging station (chargingStationId).
+              example: "IN-ECO-MDY-STATION-01"
+              x-jsonld: { "@id": "beckn:id" }
+            serviceLocation:
+              allOf:
+                - $ref: "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/attributes.yaml#/components/schemas/Location"
+                - type: object
+                  description: Location of the charging site (reuses Beckn Location).
+                  x-jsonld: { "@id": serviceLocation }
+              example:
+                "@type": "beckn:Location"
+                geo:
+                  type: "Point"
+                  coordinates: [77.6104, 12.9153]
+                address:
+                  streetAddress: "EcoPower BTM Hub, 100 Ft Rd"
+                  addressLocality: "Bengaluru"
+                  addressRegion: "Karnataka"
+                  postalCode: "560076"
+                  addressCountry: "IN"
           example:
-            "@type": "beckn:Location"
-            geo:
-              type: "Point"
-              coordinates: [77.6104, 12.9153]
-            address:
-              streetAddress: "EcoPower BTM Hub, 100 Ft Rd"
-              addressLocality: "Bengaluru"
-              addressRegion: "Karnataka"
-              postalCode: "560076"
-              addressCountry: "IN"
+            id: "IN-ECO-MDY-STATION-01"
+            serviceLocation:
+              "@type": "beckn:Location"
+              geo:
+                type: "Point"
+                coordinates: [77.6104, 12.9153]
+              address:
+                streetAddress: "EcoPower BTM Hub, 100 Ft Rd"
+                addressLocality: "Bengaluru"
+                addressRegion: "Karnataka"
+                postalCode: "560076"
+                addressCountry: "IN"
 
         amenityFeature:
           type: array
@@ -97,18 +118,6 @@ components:
           description: Nearby amenities (e.g., Restaurant, Restroom, Wi-Fi).
           example: ["RESTAURANT", "RESTROOM"]
           x-jsonld: { "@id": amenityFeature }
-
-        ocppId:
-          type: string
-          description: Site/CSMS identifier in OCPP backend.
-          example: "IN-ECO-MDY-01"
-          x-jsonld: { "@id": ocppId }
-
-        evseId:
-          type: string
-          description: EVSE identifier (e.g., OCPI/Hubject style).
-          example: "IN*ECO*01*CCS2*A"
-          x-jsonld: { "@id": evseId }
 
         roamingNetwork:
           type: string
@@ -122,12 +131,6 @@ components:
           description: Parking context of the station.
           example: "Mall"
           x-jsonld: { "@id": parkingType }
-
-        connectorId:
-          type: string
-          description: Provider-specific connector/socket id.
-          example: "CCS2-A"
-          x-jsonld: { "@id": connectorId }
 
         powerType:
           type: string
@@ -150,10 +153,9 @@ components:
           example: "FAST"
           x-jsonld: { "@id": chargingSpeed }
 
-        stationStatus:
+        vehicleType:
           type: string
-          enum: [Available, Occupied, OutOfService]
-          description: Near-real-time availability state.
-          example: "Available"
-          x-jsonld: { "@id": stationStatus }
-
+          enum: ["2-WHEELER", "3-WHEELER", "4-WHEELER"]
+          description: Type of vehicle that can use this charging service.
+          example: "4-WHEELER"
+          x-jsonld: { "@id": vehicleType }

--- a/schema/EvChargingService/v1/context.jsonld
+++ b/schema/EvChargingService/v1/context.jsonld
@@ -8,6 +8,7 @@
     "beckn": "./vocab.jsonld#",
     
     "ChargingService": "beckn:ChargingService",
+    "ChargingStation": "beckn:ChargingStation",
 
     "name": "schema:name",
     "description": "schema:description",
@@ -28,7 +29,7 @@
     "areaServed": "schema:areaServed",
     "category": "schema:category",
 
-    "connectorId": "beckn:connectorId",
+    "chargingStation": "beckn:chargingStation",
     "amenityFeature": {
       "@id": "beckn:amenityFeature",
       "@type": "@id"
@@ -49,8 +50,8 @@
       "@id": "beckn:chargingSpeed",
       "@type": "@id"
     },
-    "stationStatus": {
-      "@id": "beckn:stationStatus",
+    "vehicleType": {
+      "@id": "beckn:vehicleType",
       "@type": "@id"
     },
     "parkingType": {
@@ -97,12 +98,10 @@
     "Office": "beckn:ParkingTypeOffice",
     "Hotel": "beckn:ParkingTypeHotel",
 
-    "Available": "beckn:StationStatusAvailable",
-    "Occupied": "beckn:StationStatusOccupied",
-    "OutOfService": "beckn:StationStatusOutOfService",
-    "Out Of Service": "beckn:StationStatusOutOfService"
+    "2-WHEELER": "beckn:VehicleType2Wheeler",
+    "3-WHEELER": "beckn:VehicleType3Wheeler",
+    "4-WHEELER": "beckn:VehicleType4Wheeler"
   },
 
   "@graph": []
 }
-

--- a/schema/EvChargingService/v1/vocab.jsonld
+++ b/schema/EvChargingService/v1/vocab.jsonld
@@ -15,6 +15,12 @@
       "rdfs:comment": "A service that provides electric vehicle charging capabilities"
     },
     {
+      "@id": "beckn:ChargingStation",
+      "@type": "rdfs:Class",
+      "rdfs:label": "Charging Station",
+      "rdfs:comment": "A charging station containing station identifier and location information."
+    },
+    {
       "@id": "beckn:connectorType",
       "@type": "rdf:Property",
       "rdfs:label": "Connector type",
@@ -39,14 +45,6 @@
       "schema:rangeIncludes": "schema:Number"
     },
     {
-      "@id": "beckn:socketCount",
-      "@type": "rdf:Property",
-      "rdfs:label": "Socket count",
-      "rdfs:comment": "Number of simultaneously usable sockets/connectors.",
-      "rdfs:domain": "beckn:ChargingService",
-      "schema:rangeIncludes": "schema:Integer"
-    },
-    {
       "@id": "beckn:reservationSupported",
       "@type": "rdf:Property",
       "rdfs:label": "Reservation supported",
@@ -55,28 +53,12 @@
       "schema:rangeIncludes": "schema:Boolean"
     },
     {
-      "@id": "beckn:serviceLocation",
-      "@type": "rdf:Property",
-      "rdfs:label": "Service location",
-      "rdfs:comment": "Physical location where the charging service is offered; aligns to Beckn Location in payloads.",
-      "rdfs:domain": "beckn:ChargingService",
-      "schema:rangeIncludes": "schema:Place"
-    },
-    {
       "@id": "beckn:amenityFeature",
       "@type": "rdf:Property",
       "rdfs:label": "Amenity feature",
       "rdfs:comment": "Nearby amenities such as Restaurant, Restroom, Wi-Fi, Parking.",
       "rdfs:domain": "beckn:ChargingService",
       "schema:rangeIncludes": "beckn:AmenityFeature"
-    },
-    {
-      "@id": "beckn:ocppId",
-      "@type": "rdf:Property",
-      "rdfs:label": "OCPP identifier",
-      "rdfs:comment": "Internal identifier used by the CPO/OCPP backend.",
-      "rdfs:domain": "beckn:ChargingService",
-      "schema:rangeIncludes": "schema:Text"
     },
     {
       "@id": "beckn:evseId",
@@ -103,14 +85,6 @@
       "schema:rangeIncludes": "beckn:ParkingType"
     },
     {
-      "@id": "beckn:connectorId",
-      "@type": "rdf:Property",
-      "rdfs:label": "Connector ID",
-      "rdfs:comment": "Provider-specific connector or socket identifier.",
-      "rdfs:domain": "beckn:ChargingService",
-      "schema:rangeIncludes": "schema:Text"
-    },
-    {
       "@id": "beckn:powerType",
       "@type": "rdf:Property",
       "rdfs:label": "Power type",
@@ -135,14 +109,37 @@
       "schema:rangeIncludes": "beckn:ChargingSpeed"
     },
     {
-      "@id": "beckn:stationStatus",
+      "@id": "beckn:vehicleType",
       "@type": "rdf:Property",
-      "rdfs:label": "Station status",
-      "rdfs:comment": "Real-time availability status of the station or connector.",
+      "rdfs:label": "Vehicle type",
+      "rdfs:comment": "Type of vehicle that can use this charging service (2-WHEELER, 3-WHEELER, 4-WHEELER).",
       "rdfs:domain": "beckn:ChargingService",
-      "schema:rangeIncludes": "beckn:StationStatus"
+      "schema:rangeIncludes": "beckn:VehicleType"
     },
-
+    {
+      "@id": "beckn:chargingStation",
+      "@type": "rdf:Property",
+      "rdfs:label": "Charging station",
+      "rdfs:comment": "Charging station information including station ID and location.",
+      "rdfs:domain": "beckn:ChargingService",
+      "schema:rangeIncludes": "beckn:ChargingStation"
+    },
+    {
+      "@id": "beckn:id",
+      "@type": "rdf:Property",
+      "rdfs:label": "Charging station ID",
+      "rdfs:comment": "Unique identifier for the charging station (chargingStationId).",
+      "rdfs:domain": "beckn:ChargingStation",
+      "schema:rangeIncludes": "schema:Text"
+    },
+    {
+      "@id": "beckn:serviceLocation",
+      "@type": "rdf:Property",
+      "rdfs:label": "Service location",
+      "rdfs:comment": "Physical location where the charging service is offered; aligns to Beckn Location in payloads.",
+      "rdfs:domain": "beckn:ChargingStation",
+      "schema:rangeIncludes": "schema:Place"
+    },
     {
       "@id": "beckn:AmenityFeature",
       "@type": "schema:Enumeration",
@@ -442,44 +439,42 @@
       "schema:identifier": "Hotel"
     },
     {
-      "@id": "beckn:StationStatus",
+      "@id": "beckn:VehicleType",
       "@type": "schema:Enumeration",
-      "schema:name": "Station Status",
-      "rdfs:comment": "Enumeration of charging station availability statuses.",
+      "schema:name": "Vehicle Type",
+      "rdfs:comment": "Enumeration of vehicle types that can use the charging service.",
       "schema:hasEnumerationMember": [
-        { "@id": "beckn:StationStatusAvailable" },
-        { "@id": "beckn:StationStatusOccupied" },
-        { "@id": "beckn:StationStatusOutOfService" }
+        { "@id": "beckn:VehicleType2Wheeler" },
+        { "@id": "beckn:VehicleType3Wheeler" },
+        { "@id": "beckn:VehicleType4Wheeler" }
       ]
     },
     {
-      "@id": "beckn:StationStatusAvailable",
+      "@id": "beckn:VehicleType2Wheeler",
       "@type": [
-        "beckn:StationStatus",
+        "beckn:VehicleType",
         "schema:Enumeration"
       ],
-      "schema:name": "Available",
-      "schema:identifier": "Available"
+      "schema:name": "2-WHEELER",
+      "schema:identifier": "2-WHEELER"
     },
     {
-      "@id": "beckn:StationStatusOccupied",
+      "@id": "beckn:VehicleType3Wheeler",
       "@type": [
-        "beckn:StationStatus",
+        "beckn:VehicleType",
         "schema:Enumeration"
       ],
-      "schema:name": "Occupied",
-      "schema:identifier": "Occupied"
+      "schema:name": "3-WHEELER",
+      "schema:identifier": "3-WHEELER"
     },
     {
-      "@id": "beckn:StationStatusOutOfService",
+      "@id": "beckn:VehicleType4Wheeler",
       "@type": [
-        "beckn:StationStatus",
+        "beckn:VehicleType",
         "schema:Enumeration"
       ],
-      "schema:name": "OutOfService",
-      "schema:identifier": "OutOfService",
-      "schema:alternateName": "Out Of Service"
+      "schema:name": "4-WHEELER",
+      "schema:identifier": "4-WHEELER"
     }
   ]
 }
-

--- a/schema/EvChargingSession/v1/README.md
+++ b/schema/EvChargingSession/v1/README.md
@@ -49,6 +49,3 @@ This supports both local development and public hosting.
 
 ## 🏷️ Tags
 `ev-charging, charging-session, telemetry, billing, reservation, beckn, json-ld, schema.org, openapi`
-
-
-

--- a/schema/EvChargingSession/v1/attributes.yaml
+++ b/schema/EvChargingSession/v1/attributes.yaml
@@ -25,22 +25,36 @@ components:
         # Session state & authorization (EV-specific)
         sessionStatus:
           type: string
-          enum: [PENDING, ACTIVE, COMPLETED, INTERRUPTED]
+          enum: [PENDING, ACTIVE, STOP, COMPLETED, INTERRUPTED]
           description: High-level session state (order.state carries overall state).
           example: "ACTIVE"
           x-jsonld: { "@id": sessionStatus }
+        
+        # Charging Connector status (from OCPP status codes)
+        connectorStatus:
+          type: string
+          enum: [AVAILABLE, PREPARING, UNAVAILABLE]
+          description: Charging connector status (from OCPP status codes).
+          example: "PREPARING"
+          x-jsonld: { "@id": connectorStatus }
 
-        authorizationMode:
-          type: string
-          enum: [APP_QR, RFID, OTP]
-          description: Mode used to authorize/start the session.
-          example: "APP_QR"
-          x-jsonld: { "@id": authorizationMode }
-        authorizationOtpHint:
-          type: string
-          description: Optional OTP or hint presented to user for kiosk entry.
-          example: "Enter last 4 digits"
-          x-jsonld: { "@id": authorizationOtpHint }
+        # The Buyer Finder Fee is applied by the BAP
+        buyerFinderFee:
+          type: object
+          description: Commission payable by provider to the BAP for this offer.
+          x-jsonld: { "@id": buyerFinderFee }
+          additionalProperties: false
+          properties:
+            feeType:
+              type: string
+              enum: [PERCENTAGE, AMOUNT]
+              example: "PERCENTAGE"
+              x-jsonld: { "@id": feeType }
+            feeValue:
+              type: number
+              minimum: 0
+              example: 2.5
+              x-jsonld: { "@id": feeValue }
 
         # Technical lens for this session
         connectorType:
@@ -156,3 +170,22 @@ components:
           example: "Nexon EV"
           x-jsonld: { "@id": vehicleModel }
 
+        # Session preferences
+        preferences:
+          type: object
+          description: Charging session preferences including time windows.
+          x-jsonld: { "@id": preferences }
+          additionalProperties: false
+          properties:
+            startTime:
+              type: string
+              format: date-time
+              description: Preferred or scheduled start time for the charging session (UTC).
+              example: "2024-01-15T10:00:00Z"
+              x-jsonld: { "@id": "schema:startTime" }
+            endTime:
+              type: string
+              format: date-time
+              description: Preferred or scheduled end time for the charging session (UTC).
+              example: "2024-01-15T11:30:00Z"
+              x-jsonld: { "@id": "schema:endTime" }

--- a/schema/EvChargingSession/v1/context.jsonld
+++ b/schema/EvChargingSession/v1/context.jsonld
@@ -22,11 +22,11 @@
       "@id": "beckn:sessionStatus",
       "@type": "@id"
     },
-    "authorizationMode": {
-      "@id": "beckn:authorizationMode",
+    "connectorStatus": {
+      "@id": "beckn:connectorStatus",
       "@type": "@id"
     },
-    "authorizationOtpHint": "beckn:authorizationOtpHint",
+    "buyerFinderFee": "beckn:buyerFinderFee",
     "connectorType": {
       "@id": "beckn:connectorType",
       "@type": "@id"
@@ -42,6 +42,7 @@
     "gracePeriodMinutes": "beckn:gracePeriodMinutes",
     "vehicleMake": "beckn:vehicleMake",
     "vehicleModel": "beckn:vehicleModel",
+    "preferences": "beckn:preferences",
     "trackingId": "beckn:trackingId",
     "trackingUrl": "beckn:trackingUrl",
     "trackingStatus": "beckn:trackingStatus",
@@ -51,10 +52,9 @@
     "COMPLETED": "beckn:SessionStatusCompleted",
     "INTERRUPTED": "beckn:SessionStatusInterrupted",
 
-    "APP_QR": "beckn:AuthorizationModeAppQr",
-    "APP-QR": "beckn:AuthorizationModeAppQr",
-    "RFID": "beckn:AuthorizationModeRfid",
-    "OTP": "beckn:AuthorizationModeOtp",
+    "AVAILABLE": "beckn:ConnectorStatusAvailable",
+    "PREPARING": "beckn:ConnectorStatusPreparing",
+    "UNAVAILABLE": "beckn:ConnectorStatusUnavailable",
 
     "CCS2": "beckn:ConnectorTypeCCS2",
     "Type2": "beckn:ConnectorTypeType2",
@@ -73,4 +73,3 @@
 
   "@graph": []
 }
-

--- a/schema/EvChargingSession/v1/vocab.jsonld
+++ b/schema/EvChargingSession/v1/vocab.jsonld
@@ -24,20 +24,20 @@
       "owl:equivalentProperty": "beckn:fulfillmentStatus"
     },
     {
-      "@id": "beckn:authorizationMode",
+      "@id": "beckn:connectorStatus",
       "@type": "rdf:Property",
-      "rdfs:label": "Authorization mode",
-      "rdfs:comment": "Mode used to authorize/start the session (APP_QR, RFID, OTP).",
+      "rdfs:label": "Connector status",
+      "rdfs:comment": "Charging connector status (from OCPP status codes).",
       "rdfs:domain": "beckn:ChargingSession",
-      "schema:rangeIncludes": "beckn:AuthorizationMode"
+      "schema:rangeIncludes": "beckn:ConnectorStatus"
     },
     {
-      "@id": "beckn:authorizationOtpHint",
+      "@id": "beckn:buyerFinderFee",
       "@type": "rdf:Property",
-      "rdfs:label": "Authorization OTP hint",
-      "rdfs:comment": "Optional OTP or hint presented to user for kiosk entry.",
+      "rdfs:label": "Buyer finder fee",
+      "rdfs:comment": "Commission payable by provider to the BAP for this offer.",
       "rdfs:domain": "beckn:ChargingSession",
-      "schema:rangeIncludes": "schema:Text"
+      "schema:rangeIncludes": "schema:PriceSpecification"
     },
     {
       "@id": "beckn:connectorType",
@@ -151,6 +151,14 @@
       "rdfs:domain": "beckn:ChargingSession",
       "schema:rangeIncludes": "schema:Text"
     },
+    {
+      "@id": "beckn:preferences",
+      "@type": "rdf:Property",
+      "rdfs:label": "Preferences",
+      "rdfs:comment": "Charging session preferences including time windows.",
+      "rdfs:domain": "beckn:ChargingSession",
+      "schema:rangeIncludes": "schema:Thing"
+    },
 
     {
       "@id": "beckn:SessionStatus",
@@ -201,43 +209,42 @@
       "schema:identifier": "INTERRUPTED"
     },
     {
-      "@id": "beckn:AuthorizationMode",
+      "@id": "beckn:ConnectorStatus",
       "@type": "schema:Enumeration",
-      "schema:name": "Authorization Mode",
-      "rdfs:comment": "Enumeration of user authorization modes for initiating a charging session.",
+      "schema:name": "Connector Status",
+      "rdfs:comment": "Enumeration of charging connector statuses (from OCPP status codes).",
       "schema:hasEnumerationMember": [
-        { "@id": "beckn:AuthorizationModeAppQr" },
-        { "@id": "beckn:AuthorizationModeRfid" },
-        { "@id": "beckn:AuthorizationModeOtp" }
+        { "@id": "beckn:ConnectorStatusAvailable" },
+        { "@id": "beckn:ConnectorStatusPreparing" },
+        { "@id": "beckn:ConnectorStatusUnavailable" }
       ]
     },
     {
-      "@id": "beckn:AuthorizationModeAppQr",
+      "@id": "beckn:ConnectorStatusAvailable",
       "@type": [
-        "beckn:AuthorizationMode",
+        "beckn:ConnectorStatus",
         "schema:Enumeration"
       ],
-      "schema:name": "APP_QR",
-      "schema:identifier": "APP_QR",
-      "schema:alternateName": "APP-QR"
+      "schema:name": "AVAILABLE",
+      "schema:identifier": "AVAILABLE"
     },
     {
-      "@id": "beckn:AuthorizationModeRfid",
+      "@id": "beckn:ConnectorStatusPreparing",
       "@type": [
-        "beckn:AuthorizationMode",
+        "beckn:ConnectorStatus",
         "schema:Enumeration"
       ],
-      "schema:name": "RFID",
-      "schema:identifier": "RFID"
+      "schema:name": "PREPARING",
+      "schema:identifier": "PREPARING"
     },
     {
-      "@id": "beckn:AuthorizationModeOtp",
+      "@id": "beckn:ConnectorStatusUnavailable",
       "@type": [
-        "beckn:AuthorizationMode",
+        "beckn:ConnectorStatus",
         "schema:Enumeration"
       ],
-      "schema:name": "OTP",
-      "schema:identifier": "OTP"
+      "schema:name": "UNAVAILABLE",
+      "schema:identifier": "UNAVAILABLE"
     },
     {
       "@id": "beckn:ConnectorType",
@@ -349,4 +356,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
## Overview

Resolves #57 

Updates to EV Charging domain schemas: EV charging service/session refinements, and new payment settlement schema.

## EV Charging Service Changes

- **Item ID**: `beckn:id` now represents `connectorId` (item = connector, not socket)
- **Removed**: `ocppId`, `connectorId`, `stationStatus`, `socketCount` (item represents single connector)
- **Added**: `chargingStation` object with `id` (chargingStationId) and `serviceLocation`

## EV Charging Session Changes

- **Added**: `connectorStatus` enum (`AVAILABLE`, `PREPARING`, `UNAVAILABLE`) for OCPP tracking
- **Removed**: `authorizationMode`, `authorizationOtpHint`
- **Moved**: `buyerFinderFee` from EvChargingOffer (includes `feeType`, `feeValue`)
- **Added**: `preferences` object with `startTime`, `endTime` (UTC)

## EV Charging Offer Changes

- **Removed**: `buyerFinderFee` (moved to Session)
- **Changed**: `idleFeePolicy` from string to `PriceSpecification` object with:
  - `currency`, `value`
  - `applicableQuantity` (`unitCode`, `unitText`, `unitQuantity`)
  - `components` array

⚠️ **Requires implementation updates:**

1. EvChargingService: Item ID structure changed (now = connectorId)
2. `buyerFinderFee` moved from Offer to Session
3. `idleFeePolicy` changed from string to PriceSpecification object