### PR TITLE
feat: add AC-001, DC-001, 15A, IEC_AC, IEC_60309 connector types

### DIFF
--- a/schema/EvChargingService/v1/attributes.yaml
+++ b/schema/EvChargingService/v1/attributes.yaml
@@ -41,7 +41,7 @@ components:
         # EV-specific technicals
         connectorType:
           type: string
-          enum: [CCS2, Type2, CHAdeMO, GB_T, AC-001, DC-001, 15A, IEC_AC, IEC_60309]
+          enum: [CCS2, Type2, CHAdeMO, GB_T, AC-001, DC-001, 15A, IEC_AC, IEC_60309, Anderson, Type6, Type1]
           description: Physical connector type supported by this EVSE.
           example: CCS2
           x-jsonld: { "@id": connectorType }

--- a/schema/EvChargingService/v1/vocab.jsonld
+++ b/schema/EvChargingService/v1/vocab.jsonld
@@ -146,10 +146,18 @@
       "schema:name": "Amenity Feature",
       "rdfs:comment": "Enumeration of amenity features available near the charging service.",
       "schema:hasEnumerationMember": [
-        { "@id": "beckn:AmenityRestaurant" },
-        { "@id": "beckn:AmenityRestroom" },
-        { "@id": "beckn:AmenityWiFi" },
-        { "@id": "beckn:AmenityParking" }
+        {
+          "@id": "beckn:AmenityRestaurant"
+        },
+        {
+          "@id": "beckn:AmenityRestroom"
+        },
+        {
+          "@id": "beckn:AmenityWiFi"
+        },
+        {
+          "@id": "beckn:AmenityParking"
+        }
       ]
     },
     {
@@ -180,7 +188,10 @@
       ],
       "schema:name": "WI-FI",
       "schema:identifier": "WI-FI",
-      "schema:alternateName": ["Wi-Fi", "WiFi"]
+      "schema:alternateName": [
+        "Wi-Fi",
+        "WiFi"
+      ]
     },
     {
       "@id": "beckn:AmenityParking",
@@ -198,15 +209,42 @@
       "schema:name": "Connector Type",
       "rdfs:comment": "Enumeration of electric vehicle connector interface types.",
       "schema:hasEnumerationMember": [
-        { "@id": "beckn:ConnectorTypeCCS2" },
-        { "@id": "beckn:ConnectorTypeType2" },
-        { "@id": "beckn:ConnectorTypeCHAdeMO" },
-        { "@id": "beckn:ConnectorTypeGBT" },
-        { "@id": "beckn:ConnectorTypeAC001" },
-        { "@id": "beckn:ConnectorTypeDC001" },
-        { "@id": "beckn:ConnectorType15A" },
-        { "@id": "beckn:ConnectorTypeIECAC" },
-        { "@id": "beckn:ConnectorTypeIEC60309" }
+        {
+          "@id": "beckn:ConnectorTypeCCS2"
+        },
+        {
+          "@id": "beckn:ConnectorTypeType2"
+        },
+        {
+          "@id": "beckn:ConnectorTypeCHAdeMO"
+        },
+        {
+          "@id": "beckn:ConnectorTypeGBT"
+        },
+        {
+          "@id": "beckn:ConnectorTypeAC001"
+        },
+        {
+          "@id": "beckn:ConnectorTypeDC001"
+        },
+        {
+          "@id": "beckn:ConnectorType15A"
+        },
+        {
+          "@id": "beckn:ConnectorTypeIECAC"
+        },
+        {
+          "@id": "beckn:ConnectorTypeIEC60309"
+        },
+        {
+          "@id": "beckn:ConnectorTypeAnderson"
+        },
+        {
+          "@id": "beckn:ConnectorTypeType6"
+        },
+        {
+          "@id": "beckn:ConnectorTypeType1"
+        }
       ]
     },
     {
@@ -294,14 +332,47 @@
       "schema:alternateName": "IEC 60309"
     },
     {
+      "@id": "beckn:ConnectorTypeAnderson",
+      "@type": [
+        "beckn:ConnectorType",
+        "schema:Enumeration"
+      ],
+      "schema:name": "Anderson",
+      "schema:identifier": "Anderson"
+    },
+    {
+      "@id": "beckn:ConnectorTypeType6",
+      "@type": [
+        "beckn:ConnectorType",
+        "schema:Enumeration"
+      ],
+      "schema:name": "Type6",
+      "schema:identifier": "Type6"
+    },
+    {
+      "@id": "beckn:ConnectorTypeType1",
+      "@type": [
+        "beckn:ConnectorType",
+        "schema:Enumeration"
+      ],
+      "schema:name": "Type1",
+      "schema:identifier": "Type1"
+    },
+    {
       "@id": "beckn:PowerType",
       "@type": "schema:Enumeration",
       "schema:name": "Power Type",
       "rdfs:comment": "Enumeration of supported electrical power types.",
       "schema:hasEnumerationMember": [
-        { "@id": "beckn:PowerTypeACSinglePhase" },
-        { "@id": "beckn:PowerTypeAC3Phase" },
-        { "@id": "beckn:PowerTypeDC" }
+        {
+          "@id": "beckn:PowerTypeACSinglePhase"
+        },
+        {
+          "@id": "beckn:PowerTypeAC3Phase"
+        },
+        {
+          "@id": "beckn:PowerTypeDC"
+        }
       ]
     },
     {
@@ -338,8 +409,12 @@
       "schema:name": "Connector Format",
       "rdfs:comment": "Enumeration of connector presentation formats.",
       "schema:hasEnumerationMember": [
-        { "@id": "beckn:ConnectorFormatSocket" },
-        { "@id": "beckn:ConnectorFormatCable" }
+        {
+          "@id": "beckn:ConnectorFormatSocket"
+        },
+        {
+          "@id": "beckn:ConnectorFormatCable"
+        }
       ]
     },
     {
@@ -366,10 +441,18 @@
       "schema:name": "Charging Speed",
       "rdfs:comment": "Enumeration of marketing charging speed bands.",
       "schema:hasEnumerationMember": [
-        { "@id": "beckn:ChargingSpeedSlow" },
-        { "@id": "beckn:ChargingSpeedNormal" },
-        { "@id": "beckn:ChargingSpeedFast" },
-        { "@id": "beckn:ChargingSpeedUltraFast" }
+        {
+          "@id": "beckn:ChargingSpeedSlow"
+        },
+        {
+          "@id": "beckn:ChargingSpeedNormal"
+        },
+        {
+          "@id": "beckn:ChargingSpeedFast"
+        },
+        {
+          "@id": "beckn:ChargingSpeedUltraFast"
+        }
       ]
     },
     {
@@ -415,13 +498,27 @@
       "schema:name": "Parking Type",
       "rdfs:comment": "Enumeration of parking facility types available at the charging location.",
       "schema:hasEnumerationMember": [
-        { "@id": "beckn:ParkingTypeOnStreet" },
-        { "@id": "beckn:ParkingTypeOffStreet" },
-        { "@id": "beckn:ParkingTypeBasement" },
-        { "@id": "beckn:ParkingTypeMall" },
-        { "@id": "beckn:ParkingTypeFuelStation" },
-        { "@id": "beckn:ParkingTypeOffice" },
-        { "@id": "beckn:ParkingTypeHotel" }
+        {
+          "@id": "beckn:ParkingTypeOnStreet"
+        },
+        {
+          "@id": "beckn:ParkingTypeOffStreet"
+        },
+        {
+          "@id": "beckn:ParkingTypeBasement"
+        },
+        {
+          "@id": "beckn:ParkingTypeMall"
+        },
+        {
+          "@id": "beckn:ParkingTypeFuelStation"
+        },
+        {
+          "@id": "beckn:ParkingTypeOffice"
+        },
+        {
+          "@id": "beckn:ParkingTypeHotel"
+        }
       ]
     },
     {
@@ -496,9 +593,15 @@
       "schema:name": "Vehicle Type",
       "rdfs:comment": "Enumeration of vehicle types that can use the charging service.",
       "schema:hasEnumerationMember": [
-        { "@id": "beckn:VehicleType2Wheeler" },
-        { "@id": "beckn:VehicleType3Wheeler" },
-        { "@id": "beckn:VehicleType4Wheeler" }
+        {
+          "@id": "beckn:VehicleType2Wheeler"
+        },
+        {
+          "@id": "beckn:VehicleType3Wheeler"
+        },
+        {
+          "@id": "beckn:VehicleType4Wheeler"
+        }
       ]
     },
     {

--- a/schema/EvChargingSession/v1/attributes.yaml
+++ b/schema/EvChargingSession/v1/attributes.yaml
@@ -59,7 +59,7 @@ components:
         # Technical lens for this session
         connectorType:
           type: string
-          enum: [CCS2, Type2, CHAdeMO, GB_T, AC-001, DC-001, 15A, IEC_AC, IEC_60309]
+          enum: [CCS2, Type2, CHAdeMO, GB_T, AC-001, DC-001, 15A, IEC_AC, IEC_60309, Anderson, Type6, Type1]
           description: Connector used for this session (may differ from listing).
           example: "CCS2"
           x-jsonld: { "@id": connectorType }

--- a/schema/EvChargingSession/v1/vocab.jsonld
+++ b/schema/EvChargingSession/v1/vocab.jsonld
@@ -297,6 +297,15 @@
         },
         {
           "@id": "beckn:ConnectorTypeIEC60309"
+        },
+        {
+          "@id": "beckn:ConnectorTypeAnderson"
+        },
+        {
+          "@id": "beckn:ConnectorTypeType6"
+        },
+        {
+          "@id": "beckn:ConnectorTypeType1"
         }
       ]
     },
@@ -383,6 +392,33 @@
       "schema:name": "IEC 60309",
       "schema:identifier": "IEC_60309",
       "schema:alternateName": "IEC 60309"
+    },
+    {
+      "@id": "beckn:ConnectorTypeAnderson",
+      "@type": [
+        "beckn:ConnectorType",
+        "schema:Enumeration"
+      ],
+      "schema:name": "Anderson",
+      "schema:identifier": "Anderson"
+    },
+    {
+      "@id": "beckn:ConnectorTypeType6",
+      "@type": [
+        "beckn:ConnectorType",
+        "schema:Enumeration"
+      ],
+      "schema:name": "Type6",
+      "schema:identifier": "Type6"
+    },
+    {
+      "@id": "beckn:ConnectorTypeType1",
+      "@type": [
+        "beckn:ConnectorType",
+        "schema:Enumeration"
+      ],
+      "schema:name": "Type1",
+      "schema:identifier": "Type1"
     },
     {
       "@id": "beckn:TelemetryMetric",


### PR DESCRIPTION
This PR extends the connectorType enum to include additional connector types required by the protocol for broader EV charging infrastructure support.

Files Changed:
schema/EvChargingService/v1/attributes.yaml
 — Added new values to connectorType enum in ChargingService schema
schema/EvChargingSession/v1/attributes.yaml
 — Added new values to connectorType enum in ChargingSession schema
schema/EvChargingService/v1/vocab.jsonld
 — Added JSON-LD vocabulary definitions for the new connector types with ConnectorType enumeration members
schema/EvChargingSession/v1/vocab.jsonld
 — Added JSON-LD vocabulary definitions (mirrored from ChargingService) for session-level connector type references
 
Notes:
IEC AC and IEC 60309 use underscore-separated identifiers (IEC_AC, IEC_60309) in YAML enums and schema:identifier, with human-readable display names in schema:name and schema:alternateName.
Both EvChargingService and EvChargingSession schemas are kept in sync.
No breaking changes — existing connector types (CCS2, Type2, CHAdeMO, GB_T) remain unchanged.
