### PR TITLE
fix(#95): delegate Context, BecknEndpoint, Message, BecknAction to core_schema; slim beckn.yaml to pure transport

### DIFF
--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -1,8 +1,51 @@
+# AUTO-GENERATED — DO NOT EDIT DIRECTLY
+# Sources: api/v2.0.0/components/io/core.yaml  |  api/v2.0.0/components/schema/core.yaml  |  github.com/beckn/core_schema
+# Regenerate: cd protocol-specifications-v2 && python3 scripts/generate_endpoints.py
+#
 openapi: 3.1.1
 info:
   title: Beckn Protocol API Specification Version 2
-  description: |
-    The API specification of Beckn Protocol covering the known interaction domains of a Beckn-enabled network. Current domains include Discovery, Ordering, Fulfillment, and Post-Fulfillment. The protocol is being actively extended to cover additional domains including Reconciliation & Settlement, Observability, Reputation Ledger, and Issue & Grievance Management.
+  description: 'The API specification of Beckn Protocol — a fully resolved, concrete OpenAPI
+
+    specification with one named path per known Beckn endpoint.
+
+
+    **Interaction model:** All Beckn interactions are asynchronous. The caller sends
+
+    a request and receives a synchronous `Ack` (HTTP 200). The actual response
+
+    arrives as a separate callback on the caller''s registered callback endpoint
+
+    using the corresponding `on_<action>` endpoint.
+
+
+    **Authentication:** All requests MUST carry a Beckn Signature in the
+
+    `Authorization` header. See the `Signature` schema for the expected format.
+
+
+    ---
+
+
+    ⚠️ **THIS FILE IS AUTO-GENERATED. Do not edit directly.**
+
+
+    | Source | Path |
+
+    |--------|------|
+
+    | Abstract IO spec | `api/v2.0.0/components/io/core.yaml` |
+
+    | Transport schemas | `api/v2.0.0/components/schema/core.yaml` |
+
+    | Data model schemas | `https://github.com/beckn/core_schema` |
+
+    | Generator | `scripts/generate_endpoints.py` |
+
+
+    Regenerate: `cd protocol-specifications-v2 && python3 scripts/generate_endpoints.py`
+
+    '
   version: 2.0.0
   contact:
     name: Beckn Protocol
@@ -10,360 +53,3604 @@ info:
   license:
     name: CC-BY-NC-SA 4.0 International
     url: https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en
-
 paths:
-  /beckn/{becknEndpoint}:
-    get:
-      summary: Dispatch a Beckn protocol action on an HTTP GET endpoint (Body Mode or Query Mode)
-      description: |
-        Universal endpoint for dispatching any Beckn protocol action across a Beckn-enabled network. The `{becknEndpoint}` path parameter identifies the specific operation being performed within any supported Beckn interaction domain.
-
-        This endpoint supports two mutually exclusive modes:
-
-        **Body Mode** — The action payload is sent as a JSON request body (`BecknAction`) and the Beckn Signature is transmitted in the `Authorization` header:
-        `GET /beckn/{becknEndpoint}` with `Authorization: {Signature}` header and `BecknAction` body.
-        Used for server-to-server interactions where the caller has a registered callback endpoint and expects an asynchronous callback in return.
-
-        **Query Mode** — The action payload and signature are both expressed as URL query parameters, making the entire request a self-contained URL suitable for QR codes, deep links, bookmarkable pages, frontend UIs, IoT/embedded clients, and browser-triggered interactions:
-        `GET /beckn/{becknEndpoint}?Authorization={Signature}&RequestAction={RequestActionQuery}`
-        In Query Mode, the caller MUST NOT expect a callback. The server acknowledges receipt with an `Ack` (HTTP 200) but will not send an asynchronous callback to the caller. Query Mode is designed for stateless, one-way interactions where the originating client (e.g. a browser or QR code scanner) has no registered callback endpoint.
-
-        These two modes are mutually exclusive. If `Authorization` and `RequestAction` are present as query parameters, the request body MUST be absent and the `Authorization` header MUST be absent. If the request body is present, both query parameters MUST be absent.
-
-        This endpoint may be implemented by any Beckn Network Participant — including Beckn Application Platforms (BAPs), Beckn Provider Platforms (BPPs), Catalog Discovery Services, Catalog Publishing Services, and Registries (which follow the DeDi — Decentralized Directory — protocol for network participant lookup and public key resolution). Each participant may selectively support a subset of actions appropriate to their role.
-
-        The server responds synchronously with an `Ack` (HTTP 200) confirming receipt and successful signature validation, indicating that an asynchronous callback will follow (Body Mode). An `AckNoCallback` (HTTP 409) indicates the request was received but no callback will follow due to a business constraint. A `NackBadRequest` (HTTP 400), `NackUnauthorized` (HTTP 401), or `ServerError` (HTTP 500) indicates that the request could not be accepted.
-      parameters:
-        - name: becknEndpoint
-          in: path
-          required: true
-          schema:
-            $ref: "https://schema.beckn.io/BecknEndpoint/v2.0"
-        # Body Mode — Authorization in header (mutually exclusive with Query Mode parameters)
-        - name: Authorization
-          in: header
-          required: false
-          description: Beckn Signature authentication header (Body Mode only). See `#/components/schemas/Signature` for the expected structure.
-          schema:
-            $ref: "#/components/schemas/Signature"
-        # Query Mode — Authorization and RequestAction both in query string (mutually exclusive with Body Mode)
-        - $ref: "#/components/parameters/AuthorizationQuery"
-        - $ref: "#/components/parameters/RequestActionQuery"
-      requestBody:
-        required: false
-        description: Body Mode only — MUST be absent when query parameters are used.
-        content:
-          application/json:
-            schema:
-              $ref: "https://schema.beckn.io/BecknAction/v2.0"
-      responses:
-        "200":
-          $ref: "#/components/responses/Ack"
-        "400":
-          $ref: "#/components/responses/NackBadRequest"
-        "401":
-          $ref: "#/components/responses/NackUnauthorized"
-        "409":
-          $ref: "#/components/responses/AckNoCallback"
-        "500":
-          $ref: "#/components/responses/ServerError"
+  /beckn/discover:
     post:
-      summary: Dispatch a Beckn protocol action on an HTTP POST endpoint
-      description: |
-        Universal endpoint for dispatching any Beckn protocol action across a Beckn-enabled network. The `{action}` path parameter identifies the specific operation being performed within any supported Beckn interaction domain.
+      summary: Discover — BAP sends a discovery request
+      description: 'BAP sends a discovery intent to one or more BPPs to find catalogs matching the consumer''s requirements.
+        The intent may carry a free-text query, structured filters, spatial constraints, or media inputs.
 
-        The request body MUST conform to `BecknAction` — the unified schema for all Beckn requests and callbacks. The `action` value in the path (and in `context.action`) determines which message content schema applies: forward actions (e.g. `beckn/discover`, `beckn/select`, `beckn/init`, `beckn/confirm`) carry a request payload, while callback actions (e.g. `beckn/on_discover`, `beckn/on_select`, `beckn/on_init`, `beckn/on_confirm`) carry a callback payload. `BecknAction` validates message content for all known actions via `if/then` dispatch on `context.action`.
 
-        This endpoint may be implemented by any Beckn Network Participant — including Beckn Application Platforms (BAPs), Beckn Provider Platforms (BPPs), Catalog Discovery Services, Catalog Publishing Services, and Registries (which follow the DeDi — Decentralized Directory — protocol for network participant lookup and public key resolution). Each participant may selectively support a subset of actions appropriate to their role.
-
-        All requests MUST be authenticated using a valid Beckn Signature transmitted in the `Authorization` header. The receiver validates the signature against the sender's public key resolved from the Beckn Registry.
-
-        The server responds synchronously with an `Ack` (HTTP 200) confirming receipt and successful signature validation, indicating that an asynchronous callback will follow. An `AckNoCallback` (HTTP 409) indicates the request was received but no callback will follow due to a business constraint (e.g. agents not found, inventory unavailable, store closed). A `NackBadRequest` (HTTP 400), `NackUnauthorized` (HTTP 401), or `ServerError` (HTTP 500) indicates that the request could not be accepted.
+        **Direction:** BAP → BPP'
+      operationId: beckn_discover
+      tags:
+      - Discover
       parameters:
-        - $ref: "#/components/parameters/AuthorizationHeader"
-        - name: becknEndpoint
-          in: path
-          required: true
-          schema:
-            $ref: "https://schema.beckn.io/BecknEndpoint/v2.0"
+      - $ref: '#/components/parameters/AuthorizationHeader'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "https://schema.beckn.io/BecknAction/v2.0"
+              $ref: '#/components/schemas/DiscoverRequest'
       responses:
-        "200":
-          $ref: "#/components/responses/Ack"
-        "400":
-          $ref: "#/components/responses/NackBadRequest"
-        "401":
-          $ref: "#/components/responses/NackUnauthorized"
-        "409":
-          $ref: "#/components/responses/AckNoCallback"
-        "500":
-          $ref: "#/components/responses/ServerError"
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/on_discover:
+    post:
+      summary: On-Discover — BPP returns matching catalogs
+      description: 'BPP responds to a discover request with catalogs that match the expressed intent. Each catalog contains
+        the provider''s items, offers, fulfillment options, and pricing.
 
+
+        **Direction:** BPP → BAP (async callback)'
+      operationId: beckn_on_discover
+      tags:
+      - Discover
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnDiscoverRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/select:
+    post:
+      summary: Select — BAP selects items and requests a quote
+      description: 'BAP sends the consumer''s selected items and asks the BPP to generate a draft contract with pricing, taxes,
+        and available fulfillment options.
+
+
+        **Direction:** BAP → BPP'
+      operationId: beckn_select
+      tags:
+      - Select
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SelectRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/on_select:
+    post:
+      summary: On-Select — BPP returns a draft contract with quote
+      description: 'BPP responds with a draft contract reflecting the selected items, computed pricing, applicable taxes,
+        and fulfillment options.
+
+
+        **Direction:** BPP → BAP (async callback)'
+      operationId: beckn_on_select
+      tags:
+      - Select
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnSelectRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/init:
+    post:
+      summary: Init — BAP submits billing and fulfillment details
+      description: 'BAP submits the consumer''s billing address, chosen fulfillment option, and preferred payment method to
+        initiate an order.
+
+
+        **Direction:** BAP → BPP'
+      operationId: beckn_init
+      tags:
+      - Init
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InitRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/on_init:
+    post:
+      summary: On-Init — BPP returns final terms and payment instructions
+      description: 'BPP responds with the final order terms, complete price breakdown, and payment/settlement instructions.
+        The consumer reviews these terms before confirming.
+
+
+        **Direction:** BPP → BAP (async callback)'
+      operationId: beckn_on_init
+      tags:
+      - Init
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnInitRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/confirm:
+    post:
+      summary: Confirm — BAP confirms the order
+      description: 'BAP confirms the order after the consumer has reviewed and accepted the final terms returned in on_init.
+        This creates a binding order.
+
+
+        **Direction:** BAP → BPP'
+      operationId: beckn_confirm
+      tags:
+      - Confirm
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfirmRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/on_confirm:
+    post:
+      summary: On-Confirm — BPP acknowledges order confirmation
+      description: 'BPP acknowledges the confirmed order and returns the active contract with the assigned order identifier
+        and fulfillment state.
+
+
+        **Direction:** BPP → BAP (async callback)'
+      operationId: beckn_on_confirm
+      tags:
+      - Confirm
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnConfirmRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/status:
+    post:
+      summary: Status — BAP queries current order status
+      description: 'BAP requests the current status of a previously confirmed order by providing the order identifier.
+
+
+        **Direction:** BAP → BPP'
+      operationId: beckn_status
+      tags:
+      - Status
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StatusRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/on_status:
+    post:
+      summary: On-Status — BPP returns current order status
+      description: 'BPP returns the current state of the order, including the latest fulfillment stage, tracking state, and
+        any active alerts.
+
+
+        **Direction:** BPP → BAP (async callback)'
+      operationId: beckn_on_status
+      tags:
+      - Status
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnStatusRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/track:
+    post:
+      summary: Track — BAP requests a real-time tracking link
+      description: 'BAP requests a real-time tracking URL or WebSocket handle for an active fulfillment leg.
+
+
+        **Direction:** BAP → BPP'
+      operationId: beckn_track
+      tags:
+      - Track
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrackRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/on_track:
+    post:
+      summary: On-Track — BPP returns tracking information
+      description: 'BPP returns a tracking URL, WebSocket handle, or embedded real-time tracking feed for the active fulfillment.
+
+
+        **Direction:** BPP → BAP (async callback)'
+      operationId: beckn_on_track
+      tags:
+      - Track
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnTrackRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/update:
+    post:
+      summary: Update — BAP updates an active order
+      description: 'BAP requests a modification to an active order, such as changing the fulfillment address, adjusting quantities,
+        or adding items.
+
+
+        **Direction:** BAP → BPP'
+      operationId: beckn_update
+      tags:
+      - Update
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/on_update:
+    post:
+      summary: On-Update — BPP returns the updated contract
+      description: 'BPP returns the updated contract reflecting the applied changes, including any pricing adjustments.
+
+
+        **Direction:** BPP → BAP (async callback)'
+      operationId: beckn_on_update
+      tags:
+      - Update
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnUpdateRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/cancel:
+    post:
+      summary: Cancel — BAP cancels an active order
+      description: 'BAP cancels an active order, providing a cancellation reason code as defined in the applicable cancellation
+        policy.
+
+
+        **Direction:** BAP → BPP'
+      operationId: beckn_cancel
+      tags:
+      - Cancel
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CancelRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/on_cancel:
+    post:
+      summary: On-Cancel — BPP confirms order cancellation
+      description: 'BPP confirms the cancellation and returns the final contract state, including any applicable refund terms.
+
+
+        **Direction:** BPP → BAP (async callback)'
+      operationId: beckn_on_cancel
+      tags:
+      - Cancel
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnCancelRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/rate:
+    post:
+      summary: Rate — BAP submits ratings and feedback
+      description: 'BAP submits one or more ratings for entities in the completed order (item, fulfillment, provider, or agent),
+        optionally with feedback form submissions.
+
+
+        **Direction:** BAP → BPP'
+      operationId: beckn_rate
+      tags:
+      - Rate
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RateRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/on_rate:
+    post:
+      summary: On-Rate — BPP returns rating forms
+      description: 'BPP returns rating forms for the BAP to present to the consumer, enabling collection of structured feedback.
+
+
+        **Direction:** BPP → BAP (async callback)'
+      operationId: beckn_on_rate
+      tags:
+      - Rate
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnRateRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/support:
+    post:
+      summary: Support — BAP requests support contact information
+      description: 'BAP requests support contact details for a specific order or entity. The consumer may also initiate a
+        support callback request.
+
+
+        **Direction:** BAP → BPP'
+      operationId: beckn_support
+      tags:
+      - Support
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SupportActionRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /beckn/on_support:
+    post:
+      summary: On-Support — BPP returns support contact details
+      description: 'BPP returns support contact information including email address, telephone number, chat endpoint, and
+        available support channels.
+
+
+        **Direction:** BPP → BAP (async callback)'
+      operationId: beckn_on_support
+      tags:
+      - Support
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnSupportRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
+        '500':
+          $ref: '#/components/responses/ServerError'
 components:
   schemas:
     Ack:
+      title: Acknowledgement
+      description: Synchronous receipt acknowledgement returned for every accepted Beckn request.
       type: object
       properties:
         status:
           type: string
+          description: ACK if the request was accepted; NACK if rejected.
           enum:
-            - ACK
-            - NACK
+          - ACK
+          - NACK
         signature:
-          $ref: "#/components/schemas/CounterSignature"
+          allOf:
+          - $ref: '#/components/schemas/CounterSignature'
+          description: Counter-signature proving the receiver authenticated and processed the inbound request.
       required:
-        - status
-        - signature
-
+      - status
+      - signature
     AckNoCallback:
-      allOf:
-        - $ref: "#/components/schemas/Ack"
-        - properties:
-            error:
+      title: Acknowledgement — No Callback
+      description: 'Request received and valid, but no asynchronous callback will follow. Typical causes:
 
+        no matching agents found, inventory unavailable, store closed.
+
+        '
+      allOf:
+      - $ref: '#/components/schemas/Ack'
+      - properties:
+          error:
+            allOf:
+            - $ref: '#/components/schemas/Error'
+            description: Optional error detail explaining why no callback will follow.
     AsyncError:
-      description: Container schema for errors returned during a callback
+      title: Asynchronous Error
+      description: 'Error returned asynchronously during a callback. Wraps the base `Error` schema with
+
+        JSON-LD type annotations.
+
+        '
       allOf:
-        - $ref: "#/components/schemas/Error"
-        - properties:
-            "@context":
-              type: string
-              default: "https://schema.beckn.io/"
-            "@type":
-              type: string
-              default: "AsyncError"
-          additionalProperties: true
-
-    # Delegated to https://schema.beckn.io/BecknAction/v2.0
-    # BecknAction is the unified action envelope for all Beckn requests and callbacks.
-    # context.action (a BecknEndpoint) determines which message schema applies.
-    # message content is validated via allOf if/then dispatch.
-    # Supersedes RequestContainer and CallbackContainer.
-    BecknAction:
-      $ref: "https://schema.beckn.io/BecknAction/v2.0"
-
-    # Delegated to https://schema.beckn.io/BecknEndpoint/v2.0
-    # Kept as a component alias for backward compatibility.
-    BecknEndpoint:
-      $ref: "https://schema.beckn.io/BecknEndpoint/v2.0"
-
-    # DEPRECATED — superseded by BecknAction.
-    # Kept as a component alias for backward compatibility.
-    CallbackContainer:
-      $ref: "https://schema.beckn.io/BecknAction/v2.0"
-
-    # Delegated to https://schema.beckn.io/Context/v2.0
-    # Kept as a component alias for backward compatibility.
-    Context:
-      $ref: "https://schema.beckn.io/Context/v2.0"
-
+      - $ref: '#/components/schemas/Error'
+      - properties:
+          '@context':
+            type: string
+            default: https://schema.beckn.io/
+          '@type':
+            type: string
+            default: AsyncError
+        additionalProperties: true
     CounterSignature:
       title: Beckn HTTP Counter-Signature
-      description: |
-        A signed receipt transmitted in the synchronous `Ack` response body, proving that the receiver authenticated, received, and processed the inbound request. It is the schema realisation of the Signed Receipt of Receipt concept proposed in [Issue #69 — Strengthening Non-Repudiation and Causality in Beckn Transactions](https://github.com/beckn/protocol-specifications-v2/issues/69).
+      description: 'A signed receipt transmitted in the synchronous `Ack` response body, proving that the
 
-        `CounterSignature` shares the same wire format as `Signature` (see `#/components/schemas/Signature`) but differs in three important ways:
+        receiver authenticated, received, and processed the inbound request. It is the schema
+
+        realisation of the Signed Receipt of Receipt concept proposed in
+
+        [Issue #69](https://github.com/beckn/protocol-specifications-v2/issues/69).
+
+
+        `CounterSignature` shares the same wire format as `Signature` but differs in three ways:
+
 
         | Aspect | `Signature` | `CounterSignature` |
+
         |---|---|---|
+
         | **Signer** | Request sender (BAP/BPP) | Response receiver (BPP/BAP) |
-        | **Transmitted in** | Inbound `Authorization` header | `Ack.signature` field in the synchronous HTTP response body |
-        | **`digest`** | BLAKE2b-512 of the **inbound request** body | BLAKE2b-512 of the **Ack response** body |
-        | **`(request-digest)`** | Not present | MUST be present — BLAKE2b-512 of the **inbound request** body |
-        | **`(message-id)`** | Not present | MUST be present — the `messageId` from the inbound request `Context` |
+
+        | **Transmitted in** | Inbound `Authorization` header | `Ack.signature` in response body |
+
+        | **`digest`** | BLAKE2b-512 of **inbound request** body | BLAKE2b-512 of **Ack response** body |
+
+        | **`(request-digest)`** | Not present | MUST be present |
+
+        | **`(message-id)`** | Not present | MUST be present |
+
         | **`headers`** | `"(created) (expires) digest"` | `"(created) (expires) digest (request-digest) (message-id)"` |
 
-        **Signing string for `CounterSignature`:**
+
+        **Signing string:**
+
         ```
+
         (created): {unixTimestamp}
+
         (expires): {unixTimestamp}
+
         digest: BLAKE-512={base64DigestOfAckBody}
+
         (request-digest): BLAKE-512={base64DigestOfInboundRequestBody}
+
         (message-id): {messageId}
+
         ```
 
-        **Format:**
-        ```
-        Signature keyId="{subscriberId}|{uniqueKeyId}|{algorithm}",algorithm="{algorithm}",created="{unixTimestamp}",expires="{unixTimestamp}",headers="(created) (expires) digest (request-digest) (message-id)",signature="{base64Signature}"
-        ```
-
-        The verifier (the original sender of the request) MUST:
-        1. Recompute the BLAKE2b-512 digest of the Ack body and verify it matches `digest`.
-        2. Recompute the BLAKE2b-512 digest of their own request body and verify it matches `(request-digest)`.
-        3. Verify that `(message-id)` matches the `messageId` they sent in their request `Context`.
-        4. Resolve the receiver's public key from the registry using the `keyId` and verify the Ed25519 signature.
+        '
       allOf:
-        - $ref: "#/components/schemas/Signature"
-      example: 'Signature keyId="example-bpp.com|74b43deb-236e-4498-8f5a-ca75d6c67b9d|ed25519",algorithm="ed25519",created="1641287900",expires="1641291500",headers="(created) (expires) digest (request-digest) (message-id)",signature="mX3sHA+9gileOkXYJXh4Jg8tK0gEEMbf9yCPnFpbldhrAY+NErqL9WD+Vav7TE5tyVXGXBle9ONZi2W7o144eQ=="'
-
+      - $ref: '#/components/schemas/Signature'
+      example: Signature keyId="example-bpp.com|74b43deb-236e-4498-8f5a-ca75d6c67b9d|ed25519",algorithm="ed25519",created="1641287900",expires="1641291500",headers="(created)
+        (expires) digest (request-digest) (message-id)",signature="mX3sHA+9gileOkXYJXh4Jg8tK0gEEMbf9yCPnFpbldhrAY+NErqL9WD+Vav7TE5tyVXGXBle9ONZi2W7o144eQ=="
     Error:
-      description: Container schema for errors
+      title: Error
+      description: Base error container returned in NACK responses and async error callbacks.
       type: object
       properties:
         errorCode:
           type: string
+          description: Machine-readable error code.
         errorMessage:
           type: string
-
+          description: Human-readable error description.
     InReplyTo:
       title: In-Reply-To Reference
-      description: |
-        A cryptographic binding that ties an asynchronous `on_<action>` callback to the specific inbound request that triggered it. Implements [Issue #69 Proposal #1 — Cryptographic Request–Response Binding](https://github.com/beckn/protocol-specifications-v2/issues/69).
+      description: 'A cryptographic binding that ties an asynchronous `on_<action>` callback to the specific
 
-        Including `inReplyTo` in a callback allows the receiver (typically the BAP) to verify that the callback was produced in direct response to a specific earlier request, establishing **bilateral non-repudiation for the asynchronous leg** of a Beckn interaction. It is strictly **conversational** — it links a callback to its parent within the same transaction and MUST NOT be used to link across transaction boundaries (use `context.lineage` for cross-transaction causality).
+        inbound request that triggered it. Implements
 
-        **Verification steps for the recipient of the callback:**
-        1. Recompute the BLAKE2b-512 digest of the original request body and compare it to `digest`.
-        2. Confirm that `messageId` matches the `messageId` from the original request `Context`.
+        [Issue #69 Proposal #1 — Cryptographic Request–Response Binding](https://github.com/beckn/protocol-specifications-v2/issues/69).
 
-        Together, these two checks prove that the callback sender received **exactly the request bytes** that were originally sent.
+
+        Including `inReplyTo` in a callback establishes **bilateral non-repudiation for the
+
+        asynchronous leg** of a Beckn interaction. It is strictly conversational — it links a
+
+        callback to its parent within the same transaction. Use `context.lineage` for
+
+        cross-transaction causality.
+
+
+        **Verification steps:**
+
+        1. Recompute the BLAKE2b-512 digest of the original request body and compare to `digest`.
+
+        2. Confirm `messageId` matches the `messageId` from the original request `Context`.
+
+        '
       type: object
       properties:
         messageId:
-          description: The `messageId` of the parent request from its `Context`. Enables correlation between the async callback and the originating request.
+          description: The `messageId` of the parent request from its `Context`.
           type: string
           format: uuid
         digest:
-          description: |
-            BLAKE2b-512 hash of the parent request body bytes, encoded in Base64 and prefixed with the algorithm identifier.
+          description: 'BLAKE2b-512 hash of the parent request body, Base64-encoded with algorithm prefix.
 
             Format: `BLAKE-512={base64EncodedHash}`
 
-            Example: `BLAKE-512=b6lf6lRgOweajukcvcLsagQ2T60+85kRh/Rd2bdS+TG/5ALebOEgDJfyCrre/1+BMu5nA94o4DT3pTFXuUg7sw==`
+            '
           type: string
-          pattern: "^BLAKE-512=[A-Za-z0-9+/]+=*$"
+          pattern: ^BLAKE-512=[A-Za-z0-9+/]+=*$
       required:
-        - messageId
-        - digest
-
-    # Delegated to https://schema.beckn.io/LineageEntry/v2.0
-    # Kept as a component alias for backward compatibility.
-    LineageEntry:
-      $ref: "https://schema.beckn.io/LineageEntry/v2.0"
-
-    # Delegated to https://schema.beckn.io/Message/v2.0
-    # Kept as a component alias for backward compatibility.
-    Message:
-      $ref: "https://schema.beckn.io/Message/v2.0"
-
+      - messageId
+      - digest
     NackBadRequest:
+      title: NACK — Bad Request
+      description: Malformed or invalid request; the server could not parse or validate the payload.
       allOf:
-        - $ref: "#/components/schemas/Ack"
-        - properties:
-            status:
-              type: string
-              const: NACK
-            error:
-              $ref: "#/components/schemas/Error"
-
+      - $ref: '#/components/schemas/Ack'
+      - properties:
+          status:
+            type: string
+            const: NACK
+          error:
+            allOf:
+            - $ref: '#/components/schemas/Error'
     NackUnauthorized:
+      title: NACK — Unauthorized
+      description: Invalid or missing authentication credentials; signature could not be verified.
       allOf:
-        - $ref: "#/components/schemas/Ack"
-        - properties:
-            status:
-              type: string
-              const: NACK
-            error:
-              $ref: "#/components/schemas/Error"
-
-    # DEPRECATED — superseded by BecknAction.
-    # Kept as a component alias for backward compatibility.
-    RequestContainer:
-      $ref: "https://schema.beckn.io/BecknAction/v2.0"
-
+      - $ref: '#/components/schemas/Ack'
+      - properties:
+          status:
+            type: string
+            const: NACK
+          error:
+            allOf:
+            - $ref: '#/components/schemas/Error'
     ServerError:
-      description: Internal server error returned as a response to a Beckn API call
+      title: Server Error
+      description: Internal failure on the network participant's platform; the request could not be processed.
       type: object
-
     Signature:
       title: Beckn HTTP Signature
-      description: |
-        A digitally signed authentication credential transmitted in the HTTP `Authorization` header (or `X-Gateway-Authorization` for Beckn Gateways). The value follows the HTTP Signature scheme defined in [draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12) and as profiled by [BECKN-006](https://github.com/beckn/protocol-specifications/blob/master/docs/BECKN-006-Signing-Beckn-APIs-In-HTTP-Draft-01.md).
+      description: 'A digitally signed authentication credential in the HTTP `Authorization` header.
+
+        Follows the HTTP Signature scheme from
+
+        [draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12)
+
+        as profiled by [BECKN-006](https://github.com/beckn/protocol-specifications/blob/master/docs/BECKN-006-Signing-Beckn-APIs-In-HTTP-Draft-01.md).
+
 
         **Format:**
+
         ```
+
         Signature keyId="{subscriberId}|{uniqueKeyId}|{algorithm}",algorithm="{algorithm}",created="{unixTimestamp}",expires="{unixTimestamp}",headers="{signedHeaders}",signature="{base64Signature}"
+
         ```
 
-        **Attributes:**
 
-        | Attribute   | Description |
-        |-------------|-------------|
-        | `keyId`     | Composite key identifier with three pipe-delimited (`\|`) components: `{subscriberId}` (typically the FQDN of the subscriber), `{uniqueKeyId}` (UUID assigned by the registry when the subscriber key entry was created), and `{algorithm}` (the signing algorithm, e.g. `ed25519`). |
-        | `algorithm` | The signing algorithm. MUST be `ed25519` as per current Beckn specification. |
-        | `created`   | Unix timestamp (integer) indicating when the signature was created. A signature whose `created` value is in the future MUST NOT be processed. |
-        | `expires`   | Unix timestamp (integer) indicating when the signature expires. A signature whose `expires` value is in the past MUST NOT be processed. The difference between `expires` and `created` SHOULD equal the TTL of the request. The `expires` value MUST NOT exceed the expiry of the signing key registered in the registry. |
-        | `headers`   | Space-separated list of HTTP header names and pseudo-headers whose values are included in the signing string. MUST include `(created)`, `(expires)`, and `digest`. |
-        | `signature` | Base64-encoded Ed25519 signature over the signing string. The signing string is formed by concatenating `(created): {value}\n(expires): {value}\ndigest: BLAKE-512={digest}`, where the digest is a BLAKE2b-512 hash of the request body encoded in Base64. |
+        | Attribute | Description |
 
-        **Example:**
-        ```
-        Signature keyId="example-bap.com|ae3ea24b-cfec-495e-81f8-044aaef164ac|ed25519",algorithm="ed25519",created="1641287875",expires="1641291475",headers="(created) (expires) digest",signature="cjbhP0PFyrlSCNszJM1F/YmHDVAWsZqJUPzojnE/7TJU3fJ/rmIlgaUHEr5E0/2PIyf0tpSnWtT6cyNNlpmoAQ=="
-        ```
+        |---|---|
+
+        | `keyId` | `{subscriberId}\|{uniqueKeyId}\|{algorithm}` — FQDN, registry UUID, signing algorithm |
+
+        | `algorithm` | MUST be `ed25519` |
+
+        | `created` | Unix timestamp when the signature was created |
+
+        | `expires` | Unix timestamp when the signature expires |
+
+        | `headers` | Space-separated signed headers. MUST include `(created)`, `(expires)`, `digest` |
+
+        | `signature` | Base64-encoded Ed25519 signature over the signing string |
+
+
+        The signing string is formed by concatenating:
+
+        `(created): {value}\n(expires): {value}\ndigest: BLAKE-512={digest}`,
+
+        where `digest` is a BLAKE2b-512 hash of the request body, Base64-encoded.
+
+        '
       type: string
-      pattern: '^Signature keyId="[^|"]+\|[^|"]+\|[^"]+",algorithm="[^"]+",created="\d+",expires="\d+",headers="[^"]+",signature="[A-Za-z0-9+/]+=*"$'
-      example: 'Signature keyId="example-bap.com|ae3ea24b-cfec-495e-81f8-044aaef164ac|ed25519",algorithm="ed25519",created="1641287875",expires="1641291475",headers="(created) (expires) digest",signature="cjbhP0PFyrlSCNszJM1F/YmHDVAWsZqJUPzojnE/7TJU3fJ/rmIlgaUHEr5E0/2PIyf0tpSnWtT6cyNNlpmoAQ=="'
+      pattern: ^Signature keyId="[^|"]+\|[^|"]+\|[^"]+",algorithm="[^"]+",created="\d+",expires="\d+",headers="[^"]+",signature="[A-Za-z0-9+/]+=*"$
+      example: Signature keyId="example-bap.com|ae3ea24b-cfec-495e-81f8-044aaef164ac|ed25519",algorithm="ed25519",created="1641287875",expires="1641291475",headers="(created)
+        (expires) digest",signature="cjbhP0PFyrlSCNszJM1F/YmHDVAWsZqJUPzojnE/7TJU3fJ/rmIlgaUHEr5E0/2PIyf0tpSnWtT6cyNNlpmoAQ=="
+    TrackingRequest:
+      description: Schema definition for TrackingRequest in the Beckn Protocol v2.0.1
+      title: TrackingRequest
+      type: object
+      properties:
+        id:
+          description: Tracking reference identifier
+          type: string
+        callbackUrl:
+          description: Optional callback URL for streaming tracking coordinates/updates
+          type: string
+          format: uri
+        modeHint:
+          description: Optional delivery mode for the tracking handle.
+          type: string
+          enum:
+          - LINK_ONLY
+          - DEEP_LINK
+          - WEBHOOK
+          - WS_HANDLE
+        trackingDataSchema:
+          description: A JSON Schema (2020-12) that describes the structure of trackingData payloads.
+          $ref: https://json-schema.org/draft/2020-12/schema
+      required:
+      - id
+      x-source-id: https://schema.beckn.io/TrackingRequest/v2.0
+    RatingForm:
+      description: A form designed to capture rating and feedback from a user. This can be used by both BAP and BPP to fetch
+        ratings and feedback of their respective users.
+      title: RatingForm
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: RatingForm
+          x-jsonld:
+            '@id': beckn:RatingForm
+          target:
+            description: The entity being rated
+            type: object
+            properties:
+              '@context':
+                type: string
+                format: uri
+                const: https://schema.beckn.io/
+              '@type':
+                type: string
+                default: RatingTarget
+                x-jsonld:
+                  '@id': beckn:RatingTarget
+              id:
+                description: IF of the entity being rated (order/item/fulfillment/provider/agent).
+                type: string
+              ratingTargetType:
+                description: What is being rated. This can be any entity in the order lifecycle that influenced the overall
+                  experience of the user
+                type: string
+                enum:
+                - Order
+                - Fulfillment
+                - FulfillmentStage
+                - Provider
+                - Agent
+          range:
+            oneOf:
+            - type: object
+              properties:
+                bestRating:
+                  description: Maximum of the rating scale (default 5 if omitted).
+                  type: number
+                worstRating:
+                  description: Minimum of the rating scale (default 1 or 0 if omitted).
+                  type: number
+            - type: array
+              description: A custom rating range indexed from 0 to n
+              properties:
+                index:
+                  type: integer
+                  minimum: 0
+                value:
+                  $ref: '#/components/schemas/Descriptor'
+          feedbackForm:
+            description: A feedback form sent along with a rating request
+            allOf:
+            - $ref: '#/components/schemas/Form'
+          feedbackRequired:
+            type: boolean
+            description: Specifies whether feedback after rating is required for acceptance of rating
+        required:
+        - '@context'
+        - '@type'
+        - target
+        - feedbackRequired
+      x-source-id: https://schema.beckn.io/RatingForm/v2.0
+    Intent:
+      description: A declaration of an intent to discover catalogs.
+      title: Intent
+      type: object
+      properties:
+        textSearch:
+          description: Free text search query for items
+          type: string
+          example: gaming laptop premium tech
+        filters:
+          description: Filter criteria for items
+          type: object
+          properties:
+            type:
+              description: Type of filter expression
+              type: string
+              enum:
+              - jsonpath
+              default: jsonpath
+            expression:
+              description: Filter expression based on the specified type
+              type: string
+              example: $[?(@.rating.value >= 4.0 && @.electronic.brand.name == 'Premium Tech')]
+          required:
+          - type
+          - expression
+        spatial:
+          description: Optional array of spatial constraints (CQL2-JSON semantics).
+          type: array
+          items:
+            $ref: '#/components/schemas/SpatialConstraint'
+        media_search:
+          $ref: '#/components/schemas/MediaSearch'
+      anyOf:
+      - required:
+        - textSearch
+      - required:
+        - filters
+      - required:
+        - spatial
+      - required:
+        - filters
+        - spatial
+      x-source-id: https://schema.beckn.io/Intent/v2.0
+    Contract:
+      description: This is a JSON-LD compliant, linked-data schema that specifies a generic multi-party, digitally signed
+        Contract between a set of participants. based on the vocabulary defined in the @context. By default, it is the most
+        generic form of contract i.e beckn:Contract. However, based on the mapping being used in @context, it could take values
+        like retail:Order, mobility:Reservation, healthcare:Appointment, and so on, which will be defined as sub-classes of
+        beckn:Contract.
+      title: Contract
+      type: object
+      properties:
+        '@context':
+          description: A URL to the reference vocabulary where this schema has been defined. If missing, this field defaults
+            to `https://schema.beckn.io/`. It allows applications to fetch the mapping between the simple JSON keys of this
+            class and absolute Beckn IRIs (Internationalized Resource Identifiers), allowing conversion of standard Beckn
+            JSON payload into linked data.
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          description: A Beckn IRI on the vocabulary defined in the @context. Must start with "beckn:" followed by URL-safe
+            identifier characters.
+          type: string
+          pattern: ^beckn:[A-Za-z0-9._~-]+$
+          default: beckn:Contract
+        id:
+          description: A UUID string generated at the BPP endpoint at any stage before the confirmation of the order i.e before
+            `/on_confirm` callback. This value is intended typically for indexing or filtering. While the chances of a UUID
+            collision are rare, it is recommended to use a combination of `bppId`, `providerId` and `id` to allow for global
+            uniqueness.
+          type: string
+          format: uuid
+        displayId:
+          description: A human-readable / Agent-readable identifier of the contract intended for display or printing. This
+            value may or may not be different from `id` which is intended purely for machine-readability. Typically, this
+            value is generated after the confirmation of the order at the BPP's end.
+          type: string
+        items:
+          description: The items of value i.e resources, specified in this contract. Depending upon the context, these resources
+            could be a combination physical objects, virtual objects, services, time slots, distance travelled, alloted space,
+            and many more.
+          type: array
+          items:
+            $ref: '#/components/schemas/ContractItem'
+          minItems: 1
+        status:
+          description: The current state of the contract. Depending on the context, it could be just a code or a detailed
+            description of state.
+          oneOf:
+          - type: string
+            description: A single code describing the status of the contract.
+          - type: object
+            properties:
+              '@context':
+                type: string
+                format: uri
+                const: https://schema.beckn.io/
+              '@type':
+                type: string
+                pattern: ^beckn:[A-Za-z0-9._~-]+$
+            additionalProperties: true
+        contractValue:
+          description: An object that captures the total value of the contract including a breakup of the items, discounts,
+            fulfillment charges, and any other additional charges relevant to that context.
+          oneOf:
+          - $ref: '#/components/schemas/PriceSpecification'
+          - type: object
+            properties:
+              '@context':
+                type: string
+                format: uri
+                const: https://schema.beckn.io/
+              '@type':
+                type: string
+                pattern: ^beckn:[A-Za-z0-9._~-]+$
+            additionalProperties: true
+        participants:
+          description: The participants involved in the contract. Contracts are not always between two individuals. Several
+            entities may play a specific role in the creation, fulfillment, and post-fulfillment of the contract.
+          type: array
+          items:
+            $ref: '#/components/schemas/Participant'
+        entitlements:
+          type: array
+          items:
+            $ref: '#/components/schemas/Entitlement'
+        fulfillments:
+          description: Describes the acts performed by each participant to fulfill the contract
+          type: array
+          items:
+            $ref: '#/components/schemas/Fulfillment'
+      required:
+      - '@type'
+      - participants
+      - items
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Contract/v2.0
+    SupportRequest:
+      description: Support request by a user. If no field is set, the user can expect a public support contact info
+      title: SupportRequest
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          default: https://schema.beckn.io/
+        '@type':
+          type: string
+          const: Support
+        orderId:
+          description: The order against which support is required
+          type: string
+        ticketIds:
+          description: IDs of support ticket if open
+          type: array
+          items:
+            $ref: '#/components/schemas/SupportTicket#/properties/id'
+        callbackPhone:
+          description: Telephone number of the user for callback.
+          type: string
+      required:
+      - '@context'
+      - '@type'
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/SupportRequest/v2.0
+    Context:
+      description: 'Every API call in Beckn protocol has a context. It provides a high-level overview to the receiver about
+        the nature of the intended transaction. Typically, it is the BAP that sets the transaction context based on the consumer''s
+        location and action on their UI. The context object contains four types of fields: (1) demographic information about
+        the transaction using fields like domain, country, and region; (2) addressing details like the sending and receiving
+        platform''s ID and API URL; (3) interoperability information like the protocol version implemented by the sender;
+        and (4) transaction details like the method being called at the receiver''s endpoint, the transaction_id that represents
+        an end-to-end user session at the BAP, a message ID to pair requests with callbacks, a timestamp to capture sending
+        times, a ttl to specify the validity of the request, and a key to encrypt information if necessary.'
+      title: Context
+      type: object
+      properties:
+        action:
+          description: The Beckn endpoint being called. Must conform to BecknEndpoint format.
+          $ref: '#/components/schemas/BecknEndpoint'
+        bapId:
+          description: A globally unique identifier of the BAP. Typically the fully qualified domain name (FQDN) of the BAP.
+          type: string
+        bapUri:
+          description: API URL of the BAP for accepting callbacks from BPPs.
+          type: string
+          format: uri
+        bppId:
+          description: A globally unique identifier of the BPP. Typically the fully qualified domain name (FQDN) of the BPP.
+          type: string
+        bppUri:
+          description: API URL of the BPP for accepting calls from BAPs.
+          type: string
+          format: uri
+        messageId:
+          description: A unique value which persists during a request/callback cycle. BAPs use this value to match an incoming
+            callback from a BPP to an earlier call. Generate a fresh message_id for every new interaction.
+          type: string
+          format: uuid
+        networkId:
+          description: A unique identifier representing a group of platforms. By default, the URL of the network registry
+            on the Beckn network.
+          type: string
+        timestamp:
+          description: Time of request generation in RFC3339 format.
+          type: string
+          format: date-time
+        transactionId:
+          description: A unique value which persists across all API calls from discover through confirm. Used to indicate
+            an active user session across multiple requests.
+          type: string
+          format: uuid
+        try:
+          description: A flag to indicate that this request is intended to try an operation. Set to false by default. Set
+            to true when negotiating terms, updating, or cancelling an active contract. When true, the receiver responds with
+            the expected consequences per the terms of service agreed during init/on_init.
+          type: boolean
+          default: false
+        ttl:
+          description: The duration in ISO8601 format after timestamp for which this message holds valid.
+          type: string
+        version:
+          description: Version of Beckn protocol being used by the sender.
+          type: string
+          default: 2.0.0
+        lineage:
+          description: An optional array of causal attribution records asserting that this Beckn transaction was triggered
+            by one or more upstream Beckn interactions. Present only at transaction boundaries. MUST NOT be populated within
+            subsequent steps of the same transaction. Per current Beckn profiles, this array MUST contain at most one entry
+            when present.
+          type: array
+          maxItems: 1
+          items:
+            allOf:
+            - $ref: '#/components/schemas/LineageEntry'
+      required:
+      - action
+      - bapId
+      - bapUri
+      - messageId
+      - timestamp
+      - transactionId
+      - version
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Context/v2.0
+    SupportInfo:
+      description: Canonical support contact for an entity, mapped to schema.org ContactPoint.
+      title: SupportInfo
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          default: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: beckn:SupportInfo
+        channels:
+          description: Available support channels.
+          type: array
+          items:
+            type: string
+            enum:
+            - PHONE
+            - EMAIL
+            - WEB
+            - CHAT
+            - WHATSAPP
+            - IN_APP
+            - OTHER
+        email:
+          description: Support email address.
+          type: string
+          format: email
+        hoursAvailable:
+          description: Human-readable support hours (local time)
+          type: string
+        name:
+          description: Name of the support organization or contact.
+          type: string
+        telephone:
+          description: Telephone number.
+          type: string
+        chat:
+          description: Embeddable chat endpoint for support.
+          type: string
+          format: uri
+        url:
+          description: Generic URL to a support page.
+          type: string
+          format: uri
+        callbackStatus:
+          description: Status of a support callback request. Indicates whether a callback has been requested, scheduled, or
+            completed.
+          type: string
+      required:
+      - '@context'
+      - '@type'
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/SupportInfo/v2.0
+    RatingInput:
+      description: A form designed to capture rating and feedback from a user. This can be used by both BAP and BPP to fetch
+        ratings and feedback of their respective users.
+      title: RatingInput
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: RatingForm
+          x-jsonld:
+            '@id': beckn:RatingForm
+        target:
+          description: The entity being rated
+          type: object
+          properties:
+            '@context':
+              type: string
+              format: uri
+              const: https://schema.beckn.io/
+            '@type':
+              type: string
+              default: RatingTarget
+              x-jsonld:
+                '@id': beckn:RatingTarget
+            id:
+              description: IF of the entity being rated (order/item/fulfillment/provider/agent).
+              type: string
+            category:
+              description: What is being rated. This can be any entity in the order lifecycle that influenced the overall
+                experience of the user
+              type: string
+              enum:
+              - Order
+              - Fulfillment
+              - FulfillmentStage
+              - Provider
+              - Agent
+          required:
+          - '@context'
+          - '@type'
+          - id
+          - category
+        range:
+          oneOf:
+          - type: object
+            properties:
+              bestRating:
+                description: Maximum of the rating scale (default 5 if omitted).
+                type: number
+              worstRating:
+                description: Minimum of the rating scale (default 1 or 0 if omitted).
+                type: number
+          - type: array
+            description: A custom rating range indexed from 0 to n
+            properties:
+              index:
+                type: integer
+                minimum: 0
+              value:
+                $ref: '#/components/schemas/Descriptor'
+        feedbackFormSubmission:
+          description: The submission to the feedback form sent along with a rating request
+          allOf:
+          - $ref: '#/components/schemas/FormSubmission'
+      required:
+      - '@context'
+      - '@type'
+      - target
+      - range
+      x-source-id: https://schema.beckn.io/RatingInput/v2.0
+    Message:
+      title: Message
+      description: Open payload container for Beckn action messages. The specific content of the message object is determined
+        by the action value in the accompanying Context. BecknAction constrains message content based on context.action via
+        if/then dispatch rules. Direct use of this schema provides no payload constraints — use BecknAction for validated
+        action payloads.
+      type: object
+      additionalProperties: true
+      x-source-id: https://schema.beckn.io/Message/v2.0
+    Catalog:
+      description: Catalog schema for Beckn Protocol v2.0.1
+      title: Catalog
+      type: object
+      properties:
+        '@context':
+          description: JSON-LD context URI for the core Catalog schema
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          description: Type of the catalog
+          type: string
+          const: beckn:Catalog
+        bppId:
+          description: BPP (Beckn Protocol Provider) identifier that publishes this catalog
+          type: string
+          example: bpp.example.com
+        bppUri:
+          description: BPP (Beckn Protocol Provider) URI endpoint
+          type: string
+          format: uri
+          example: https://bpp.example.com
+        descriptor:
+          description: A verbal summary of the catalog for humans, AI agents, etc to read and understand the context.
+          type: object
+        id:
+          description: Unique identifier for the catalog
+          type: string
+          example: catalog-electronics-001
+        isActive:
+          description: Whether the catalog is active
+          type: boolean
+          default: true
+        items:
+          description: Array of beckn core Item entities in this catalog
+          type: array
+          items:
+            $ref: '#/components/schemas/Item'
+        offers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Offer'
+        providerId:
+          description: Reference to the provider that owns this catalog
+          type: string
+          example: tech-store-001
+        validity:
+          type: object
+      required:
+      - '@context'
+      - '@type'
+      - id
+      - descriptor
+      - bppId
+      - bppUri
+      - items
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Catalog/v2.0
+    Tracking:
+      description: Non-streaming tracking handle per legacy semantics (url/transport/status).
+      title: Tracking
+      type: object
+      properties:
+        '@context':
+          description: TBD
+          type: string
+          format: uri
+          default: https://schema.beckn.io/
+        '@type':
+          description: TBD
+          type: string
+          default: beckn:Tracking
+        expiresAt:
+          description: ISO 8601 expiry timestamp for the tracking handle.
+          type: string
+          format: date-time
+        trackingStatus:
+          type: string
+          enum:
+          - ACTIVE
+          - DISABLED
+          - COMPLETED
+        url:
+          description: Link/handle to off-network tracking UI or endpoint.
+          type: string
+          format: uri
+      required:
+      - '@context'
+      - '@type'
+      - url
+      - trackingStatus
+      x-jsonld:
+        '@type': schema:TrackAction
+        trackingStatus: $.trackingStatus
+        schema:target: $.url
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Tracking/v2.0
+    LineageEntry:
+      title: LineageEntry
+      description: A causal attribution record asserting that the Beckn transaction in which this entry appears was triggered
+        by a specific upstream Beckn interaction. Used in Context.lineage at transaction boundaries — when a new transaction
+        is initiated as a direct consequence of an upstream interaction. MUST NOT be included within subsequent steps of the
+        same transaction, and MUST NOT be propagated by downstream responses.
+      type: object
+      properties:
+        action:
+          description: The Beckn endpoint of the upstream message that caused this transaction to be initiated.
+          $ref: '#/components/schemas/BecknEndpoint'
+        transactionId:
+          description: The transactionId of the upstream Beckn transaction, taken from its Context.
+          type: string
+          format: uuid
+        messageId:
+          description: The messageId of the specific upstream message that directly triggered the creation of this transaction.
+          type: string
+          format: uuid
+        digest:
+          description: 'BLAKE2b-512 hash of the upstream message body bytes, encoded in Base64 and prefixed with the algorithm
+            identifier. Format: BLAKE-512={base64EncodedHash}'
+          type: string
+          pattern: ^BLAKE-512=[A-Za-z0-9+/]+=*$
+          example: BLAKE-512=b6lf6lRgOweajukcvcLsagQ2T60+85kRh/Rd2bdS+TG/5ALebOEgDJfyCrre/1+BMu5nA94o4DT3pTFXuUg7sw==
+      required:
+      - action
+      - transactionId
+      - messageId
+      - digest
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/LineageEntry/v2.0
+    BecknEndpoint:
+      title: BecknEndpoint
+      description: A Beckn protocol endpoint identifier. Must start with the prefix "beckn/" followed by one or more lowercase
+        segments (letters and underscores only) separated by forward slashes. Standard endpoints are listed in the examples
+        below. New actors may define extension endpoints without modifying this schema — the pattern accepts any conforming
+        beckn/ prefixed string.
+      type: string
+      pattern: ^beckn\/[a-z_]+(?:\/[a-z_]+)*$
+      examples:
+      - beckn/discover
+      - beckn/on_discover
+      - beckn/select
+      - beckn/on_select
+      - beckn/init
+      - beckn/on_init
+      - beckn/confirm
+      - beckn/on_confirm
+      - beckn/status
+      - beckn/on_status
+      - beckn/track
+      - beckn/on_track
+      - beckn/update
+      - beckn/on_update
+      - beckn/cancel
+      - beckn/on_cancel
+      - beckn/rate
+      - beckn/on_rate
+      - beckn/support
+      - beckn/on_support
+      x-source-id: https://schema.beckn.io/BecknEndpoint/v2.0
+    Descriptor:
+      description: Schema definition for Descriptor in the Beckn Protocol v2.0.1
+      title: Descriptor
+      type: object
+      properties:
+        '@context':
+          description: Use case specific JSON-LD context. This can change from use case to use case, even within a domain.
+          type: string
+          format: uri
+          default: https://schema.beckn.io/
+        '@type':
+          description: Type of the descriptor. The type can be overriden with a context-specific type
+          type: string
+          default: beckn:Descriptor
+        longDesc:
+          description: Detailed description of the item
+          type: string
+          example: Powerful gaming laptop with NVIDIA RTX graphics, fast SSD storage, and high-refresh display
+        shortDesc:
+          description: Short description of the item
+          type: string
+          example: High-performance gaming laptop with RTX graphics
+        name:
+          description: Name of the entity being described
+          type: string
+          example: Premium Gaming Laptop Pro
+        thumbnailImage:
+          description: Name of the entity being described
+          type: string
+          format: uri
+        docs:
+          description: Links to downloadable documents
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        mediaFile:
+          description: Links to multimedia files and images
+          type: array
+          items:
+            $ref: '#/components/schemas/MediaFile'
+      required:
+      - '@type'
+      x-source-id: https://schema.beckn.io/Descriptor/v2.0
+    Form:
+      description: Describes a form
+      title: Form
+      type: object
+      properties:
+        '@context':
+          description: CPD
+          type: string
+          format: uri
+          default: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: beckn:Form
+        data:
+          description: The form submission data
+          type: object
+          additionalProperties:
+            type: string
+        mimeType:
+          description: This field indicates the nature and format of the form received by querying the url. MIME types are
+            defined and standardized in IETF's RFC 6838.
+          type: string
+        submissionId:
+          type: string
+          format: uuid
+        url:
+          description: The URL from where the form can be fetched. The content fetched from the url must be processed as per
+            the mimeType specified in this object. Once fetched, the rendering platform can choosed to render the form as-is
+            as an embeddable element; or process it further to blend with the theme of the application. In case the interface
+            is non-visual, the the render can process the form data and reproduce it as per the standard specified in the
+            form.
+          type: string
+          format: uri
+      required:
+      - '@context'
+      - '@type'
+      x-source-id: https://schema.beckn.io/Form/v2.0
+    MediaSearch:
+      description: Container for multimodal search inputs and configuration. Supports searching through **images, audio notes,
+        and videos** alongside text, filters, and spatial predicates. For GET, this object should be JSON-encoded and URL-escaped.
+      title: MediaSearch
+      type: object
+      properties:
+        media:
+          description: One or more references to **images, audio notes, or videos** supplied as part of a multimodal search.
+            Each entry references a media resource accessible via HTTPS or data URI.
+          type: array
+          items:
+            $ref: '#/components/schemas/MediaInput'
+          example:
+          - id: snap-1
+            type: image
+            url: https://cdn.example.com/user/snaps/ccs2-cable.jpg
+            contentType: image/jpeg
+        options:
+          description: Options controlling how the discovery engine interprets the supplied media — e.g., whether to perform
+            OCR/ASR, semantic similarity, or object detection.
+          $ref: '#/components/schemas/MediaSearchOptions'
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/MediaSearch/v2.0
+    SpatialConstraint:
+      description: "**Spatial predicate** using **OGC CQL2 (JSON semantics)** applied to one or more geometry targets in an\
+        \ item. This is where clients express spatial intent.\nKey ideas: - `targets`: one or more **JSONPath-like** pointers\
+        \ that locate geometry\n\n  fields within each item document (e.g., `$['availableAt'][*]['geo']`).\n- `op`: spatial\
+        \ operator (CQL2). Common ones:\n\n    • `S_WITHIN`     (A is completely inside B)\n    • `S_INTERSECTS` (A intersects\
+        \ B)\n    • `S_CONTAINS`   (A contains B)\n    • `S_DWITHIN`    (A within distance of B)\n- `geometry`: **GeoJSON**\
+        \ literal used as the predicate reference geometry. - `distanceMeters`: required for `S_DWITHIN` when using a GeoJSON\
+        \ Point/shape. - `quantifier`: if a target resolves to an array, choose whether **ANY** (default),\n\n  **ALL**, or\
+        \ **NONE** of elements must satisfy the predicate.\n\nCRS: unless otherwise stated, all coordinates are **EPSG:4326**.\n"
+      title: SpatialConstraint
+      type: object
+      properties:
+        op:
+          description: OGC CQL2 spatial operator.
+          type: string
+          enum:
+          - S_WITHIN
+          - S_CONTAINS
+          - S_INTERSECTS
+          - S_DISJOINT
+          - S_OVERLAPS
+          - S_CROSSES
+          - S_TOUCHES
+          - S_EQUALS
+          - S_DWITHIN
+        targets:
+          description: '''One or more JSONPath-like pointers to geometry fields within the item.  Example pointers:  - `$[''''availableAt''''][*][''''geo'''']`
+            (array of site Points)  - `$[''''itemAttributes''''][''''ride:dropOff''''][''''geo'''']` (drop zone Polygon)''
 
+            '
+          oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+        geometry:
+          $ref: '#/components/schemas/GeoJSONGeometry'
+        distanceMeters:
+          description: 'For `S_DWITHIN`: maximum distance in meters from the target geometry to `geometry` (e.g., "within
+            5000 m of this Point"). Ignored for other ops.'
+          type: number
+          minimum: 0
+        quantifier:
+          description: '''How to evaluate when `targets` resolves to an array - - **any**: at least one element matches (default)
+            - **all**: every element must match  - **none**: no element may match''
+
+            '
+          type: string
+          enum:
+          - ANY
+          - ALL
+          - NONE
+          default: any
+        srid:
+          description: Coordinate Reference System identifier for `geometry`. Default is `"EPSG:4326"`. If provided, servers
+            MAY reproject to EPSG:4326 internally.
+          type: string
+          example: EPSG:4326
+      required:
+      - op
+      - targets
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/SpatialConstraint/v2.0
+    PriceSpecification:
+      description: Schema definition for PriceSpecification in the Beckn Protocol v2.0.1
+      title: PriceSpecification
+      type: object
+      additionalProperties: true
+      properties:
+        currency:
+          type: string
+          description: ISO 4217 code
+        value:
+          type: number
+          description: Total value for this price specification
+        applicableQuantity:
+          $ref: '#/components/schemas/Quantity'
+          x-jsonld:
+            '@id': schema:eligibleQuantity
+        components:
+          type: array
+          description: Optional components (tax, shipping, discount, fee, surcharge)
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                - UNIT
+                - TAX
+                - DELIVERY
+                - DISCOUNT
+                - FEE
+                - SURCHARGE
+              value:
+                type: number
+              currency:
+                type: string
+              description:
+                type: string
+        x-jsonld:
+          '@id': schema:PriceSpecification
+      x-source-id: https://schema.beckn.io/PriceSpecification/v2.0
+    ContractItem:
+      description: A line item within a Contract, linking an accepted Offer and ordered Item with quantity and price.
+      title: ContractItem
+      type: object
+      properties:
+        acceptedOffer:
+          description: Offer applied to this line (if different from contract-level)
+          x-jsonld:
+            '@id': schema:acceptedOffer
+          allOf:
+          - $ref: '#/components/schemas/Offer'
+        itemId:
+          x-jsonld:
+            '@id': schema:orderedItem
+          allOf:
+          - $ref: '#/components/schemas/Item#/properties/id'
+        lineId:
+          description: Unique line id within contract
+          type: string
+        contractItemAttributes:
+          description: Line-level Attribute Pack (options, substitutions, ESG, etc.)
+          allOf:
+          - $ref: '#/components/schemas/Attributes'
+        price:
+          description: Line price composition (unit/tax/delivery/discount)
+          x-jsonld:
+            '@id': schema:priceSpecification
+          allOf:
+          - $ref: '#/components/schemas/PriceSpecification'
+        quantity:
+          x-jsonld:
+            '@id': beckn:quantity
+          allOf:
+          - $ref: '#/components/schemas/Quantity'
+      required:
+      - itemId
+      x-source-id: https://schema.beckn.io/ContractItem/v2.0
+    Entitlement:
+      description: A contractually granted, policy-governed right that allows a specific party to access, use, or claim a
+        defined economic resource within stated scope and validity constraints. It represents the enforceable permission created
+        by an order, independent of the credential used to exercise it.
+      title: Entitlement
+      type: object
+      properties:
+        '@context':
+          description: CPD
+          type: string
+          format: uri
+          default: https://schema.beckn.io/
+        '@type':
+          description: The domain-specific type of entitlement that allows domains to extend this schema
+          type: string
+          default: beckn:Entitlement
+        id:
+          description: A unique identifier for this entitlement within the entitlement provider's namespace
+          type: string
+        resource:
+          description: The resource being availed or accessed against this entitlement
+          allOf:
+          - $ref: '#/components/schemas/ContractItem#/properties/lineId'
+        descriptor:
+          description: Human-readable information regarding the entitlement like QR-code images, attached documents containing
+            terms and conditions, video or audio files instructing the user on how to use the entitlement
+          allOf:
+          - $ref: '#/components/schemas/Descriptor'
+        credentials:
+          type: array
+          items:
+            $ref: '#/components/schemas/Descriptor'
+      additionalProperties: true
+      required:
+      - '@context'
+      - '@type'
+      - id
+      - descriptor
+      x-source-id: https://schema.beckn.io/Entitlement/v2.0
+    Participant:
+      description: Schema definition for Participant in the Beckn Protocol v2.0.1
+      title: Participant
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: beckn:Participant
+        credentials:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
+        displayName:
+          type: string
+        email:
+          type: string
+          format: email
+        id:
+          type: string
+        rating:
+          $ref: '#/components/schemas/Rating'
+        role:
+          description: Role of participant (consumer, recipient, rider, patient, operator, etc.)
+          type: string
+        skills:
+          type: array
+          items:
+            $ref: '#/components/schemas/Skill'
+        telephone:
+          type: string
+      required:
+      - '@context'
+      - '@type'
+      - id
+      - role
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Participant/v2.0
+    Fulfillment:
+      description: Schema definition for Fulfillment in the Beckn Protocol v2.0.1
+      title: Fulfillment
+      type: object
+      properties:
+        '@context':
+          description: JSON-LD context URI
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          enum:
+          - Fulfillment
+          x-jsonld:
+            '@id': schema:Thing
+        agent:
+          description: The entity that directly performs the fulfillment
+          allOf:
+          - $ref: '#/components/schemas/FulfillmentAgent'
+        fulfillmentAttributes:
+          description: Extensible set of domain-specific attributes describing the fulfillment
+          allOf:
+          - $ref: '#/components/schemas/Attributes'
+        id:
+          description: Fulfillment identifier
+          type: string
+          x-jsonld:
+            '@id': schema:identifier
+        instructions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Descriptor'
+        mode:
+          description: Extensible set of attributes describing the mode of fulfillment. Varies with Industry Use Case
+          allOf:
+          - $ref: '#/components/schemas/FulfillmentMode'
+          x-jsonld:
+            '@id': beckn:FulfillmentMode
+        participants:
+          description: A list of participants who are entitled to receive the fulfillment of the order. By default, it is
+            the consumer who placed the order
+          type: array
+          items:
+            $ref: '#/components/schemas/Participant'
+          minItems: 1
+        state:
+          description: The current state of fulfillment
+          allOf:
+            $ref: '#/components/schemas/State'
+        stages:
+          description: The various stages of the fulfillment
+          type: array
+          items:
+            $ref: '#/components/schemas/FulfillmentStage'
+          minItems: 1
+        trackingEnabled:
+          description: Whether tracking is enabled / possible for this fulfillment
+          type: boolean
+      required:
+      - '@context'
+      - '@type'
+      - mode
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Fulfillment/v2.0
+    SupportTicket:
+      description: A support ticket raised against an order
+      title: SupportTicket
+      type: object
+      properties:
+        id:
+          description: Ticket ID
+          type: string
+        supportTicketAttributes:
+          $ref: '#/components/schemas/Attributes'
+      x-source-id: https://schema.beckn.io/SupportTicket/v2.0
+    FormSubmission:
+      title: FormSubmission
+      description: A user's submitted response to a Beckn form. Captures the filled-in field values keyed by form field names.
+        Typically attached to a RatingInput to convey feedback form answers alongside a rating.
+      type: object
+      properties:
+        id:
+          description: Identifier of the form that was submitted. Typically the form's URL or the value of the form's url
+            field.
+          type: string
+          format: uri
+        submissionId:
+          description: Unique identifier for this form submission instance.
+          type: string
+          format: uuid
+        data:
+          description: Key-value map of form field names to submitted values. Keys correspond to the field identifiers defined
+            in the form; values are the user's responses as strings.
+          type: object
+          additionalProperties:
+            type: string
+        submittedAt:
+          description: Timestamp at which the form was submitted, in RFC 3339 / ISO 8601 format.
+          type: string
+          format: date-time
+      required:
+      - data
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/FormSubmission/v2.0
+    Item:
+      description: Schema definition for Item in the Beckn Protocol v2.0.1
+      title: Item
+      type: object
+      properties:
+        '@context':
+          description: JSON-LD context URI for the core Item schema
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          description: Type of the core item
+          type: string
+          enum:
+          - Item
+        availabilityWindow:
+          description: Time periods when the item is available
+          type: array
+          items:
+            $ref: '#/components/schemas/TimePeriod'
+        availableAt:
+          description: Physical locations where the item is available
+          type: array
+          items:
+            $ref: '#/components/schemas/Location'
+        category:
+          $ref: '#/components/schemas/CategoryCode'
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Constraint'
+        descriptor:
+          $ref: '#/components/schemas/Descriptor'
+        id:
+          description: Unique identifier for the item
+          type: string
+          example: gaming-laptop-001
+        isActive:
+          description: Whether the item is active
+          type: boolean
+          default: true
+        itemAttributes:
+          $ref: '#/components/schemas/Attributes'
+        networkId:
+          description: Array of network identifiers for the BAP (Beckn App Provider) that offers this item
+          type: array
+          items:
+            type: string
+          example:
+          - bap.net/electronics
+          - bap.net/tech
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/Policy'
+        provider:
+          $ref: '#/components/schemas/Provider'
+        rateable:
+          description: Whether the item can be rated by customers
+          type: boolean
+          example: true
+        rating:
+          $ref: '#/components/schemas/Rating'
+      required:
+      - '@context'
+      - '@type'
+      - id
+      - descriptor
+      - provider
+      - itemAttributes
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Item/v2.0
+    Offer:
+      description: Schema definition for Offer in the Beckn Protocol v2.0.1
+      title: Offer
+      type: object
+      properties:
+        '@context':
+          description: JSON-LD context URI for the core offer schema
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          description: TPD
+          type: string
+          enum:
+          - Offer
+          x-jsonld:
+            '@id': schema:Offer
+        acceptedPaymentMethod:
+          $ref: '#/components/schemas/AcceptedPaymentMethod'
+        addOnItems:
+          description: Optional extras modeled as items (e.g., toppings, accessories)
+          type: array
+          items:
+            $ref: '#/components/schemas/Item#/properties/id'
+          x-jsonld:
+            '@id': schema:addOn
+        addOns:
+          description: Optional extra Offers that can be attached (e.g., warranty, gift wrap)
+          type: array
+          items:
+            $ref: '#/components/schemas/Offer#/properties/id'
+          x-jsonld:
+            '@id': schema:addOn
+        constraints:
+          type: array
+          items:
+            $ref: '#/components/schemas/Constraint'
+        descriptor:
+          $ref: '#/components/schemas/Descriptor'
+        eligibleRegion:
+          description: Regions where the offer is eligible
+          type: array
+          items:
+            $ref: '#/components/schemas/Location'
+        id:
+          description: Unique id for this offer
+          type: string
+          x-jsonld:
+            '@id': schema:identifier
+        isActive:
+          description: Whether the offer is active
+          type: boolean
+          default: true
+        items:
+          description: Base item(s) the offer applies to (single or bundle)
+          type: array
+          items:
+            $ref: '#/components/schemas/Item#/properties/id'
+          x-jsonld:
+            '@id': schema:itemOffered
+          minItems: 1
+        offerAttributes:
+          description: Attribute Pack attachment (pricing models, discounts, rail terms, etc.)
+          allOf:
+          - $ref: '#/components/schemas/Attributes'
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/Policy'
+        price:
+          description: Price snapshot; detailed models can live in offerAttributes
+          x-jsonld:
+            '@id': schema:priceSpecification
+          allOf:
+          - $ref: '#/components/schemas/PriceSpecification'
+        provider:
+          description: Seller / provider of this offer
+          x-jsonld:
+            '@id': schema:seller
+          allOf:
+          - $ref: '#/components/schemas/Provider#/properties/id'
+        validity:
+          description: Offer validity window
+          x-jsonld:
+            '@id': schema:availabilityStarts|schema:availabilityEnds
+          allOf:
+          - $ref: '#/components/schemas/TimePeriod'
+      required:
+      - '@context'
+      - '@type'
+      - id
+      - descriptor
+      - provider
+      - items
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Offer/v2.0
+    MediaFile:
+      description: A image, audio, or video typically intended for display purposes
+      title: MediaFile
+      type: object
+      properties:
+        label:
+          description: The display name of the media file
+          type: string
+        mimeType: MIME type if 'data' is provided (application/pdf, image/png).
+        uri:
+          description: URL to the document
+          type: string
+          format: uri
+      x-source-id: https://schema.beckn.io/MediaFile/v2.0
+    Document:
+      description: A document, that can be parsed, printed, download or displayed. This has intentionally been kept separate
+        from MediaFile as they may contain additional attributes like signature, schema etc.
+      title: Document
+      type: object
+      properties:
+        label:
+          description: The display name of the media file
+          type: string
+        mimeType:
+          description: MIME type if 'data' is provided (application/pdf, image/png, application/json).
+          type: string
+        standard:
+          description: Describes the schema type in case the document follows a standard schema like a verifiableCredential
+          type: string
+        url:
+          description: URL to the document
+          type: string
+          format: uri
+        security:
+          type: object
+          properties:
+            checksum:
+              type: string
+            checksumAlgorithm:
+              type: string
+              enum:
+              - SHA256
+              - SHA512
+              - OTHER
+            signature:
+              type: string
+            signatureAlgorithm:
+              type: string
+              description: e.g., Ed25519, ES256
+            keyId:
+              type: string
+        required:
+        - label
+        - url
+        - mimeType
+      x-source-id: https://schema.beckn.io/Document/v2.0
+    MediaSearchOptions:
+      description: How the discovery engine should use the provided media inputs.
+      title: MediaSearchOptions
+      type: object
+      properties:
+        goals:
+          description: Desired processing goals for the media.
+          type: array
+          items:
+            type: string
+            enum:
+            - VISUAL_SIMILARITY
+            - VISUAL_OBJECT_DETECT
+            - TEXT_FROM_IMAGE
+            - TEXT_FROM_AUDIO
+            - SEMANTIC_AUDIO_MATCH
+            - SEMANTIC_VIDEO_MATCH
+        augmentTextSearch:
+          description: Whether to append extracted text from OCR/ASR to `textSearch`.
+          type: boolean
+          default: true
+        restrictResultsToMediaProximity:
+          description: Restrict results to spatial proximity of media-derived coordinates (e.g., EXIF GPS tags).
+          type: boolean
+          default: false
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/MediaSearchOptions/v2.0
+    MediaInput:
+      description: Reference to an image, audio clip, or video used for multimodal search.
+      title: MediaInput
+      type: object
+      properties:
+        id:
+          description: Client-supplied identifier for this media input.
+          type: string
+        type:
+          description: Media category.
+          type: string
+          enum:
+          - image
+          - audio
+          - video
+        url:
+          description: HTTPS URL or data URI pointing to the media resource.
+          type: string
+          format: uri
+        contentType:
+          description: MIME type, e.g., image/jpeg, audio/mpeg, video/mp4.
+          type: string
+        textHint:
+          description: Optional pre-extracted text (OCR/ASR) for search augmentation.
+          type: string
+        language:
+          description: Language code (BCP-47) of `textHint` or spoken audio.
+          type: string
+        startMs:
+          description: Optional start offset in milliseconds (for audio/video segments).
+          type: integer
+        endMs:
+          description: Optional end offset in milliseconds (for audio/video segments).
+          type: integer
+      required:
+      - type
+      - url
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/MediaInput/v2.0
+    GeoJSONGeometry:
+      description: "**GeoJSON geometry** per RFC 7946. Coordinates are in **EPSG:4326 (WGS-84)** and MUST follow **[longitude,\
+        \ latitude, (altitude?)]** order.\nSupported types: - Point, LineString, Polygon - MultiPoint, MultiLineString, MultiPolygon\
+        \ - GeometryCollection (uses `geometries` instead of `coordinates`)\nNotes: - For rectangles, use a Polygon with a\
+        \ single linear ring where the first\n  and last positions are identical.\n- Circles are **not native** to GeoJSON.\
+        \ For circular searches, use\n  `SpatialConstraint` with `op: s_dwithin` and a Point + `distanceMeters`,\n  or approximate\
+        \ the circle as a Polygon.\n- Optional `bbox` is `[west, south, east, north]` in degrees.\n"
+      title: GeoJSONGeometry
+      type: object
+      properties:
+        bbox:
+          description: Optional bounding box `[west, south, east, north]` in degrees.
+          type: array
+          minItems: 4
+          maxItems: 4
+        coordinates:
+          description: Coordinates per RFC 7946 for all types **except** GeometryCollection. Order is **[lon, lat, (alt)]**.
+            For Polygons, this is an array of linear rings; each ring is an array of positions.
+          type: array
+        geometries:
+          description: Member geometries when `type` is **GeometryCollection**.
+          type: array
+          items:
+            $ref: '#/components/schemas/GeoJSONGeometry'
+        type:
+          type: string
+          enum:
+          - Point
+          - LineString
+          - Polygon
+          - MultiPoint
+          - MultiLineString
+          - MultiPolygon
+          - GeometryCollection
+      required:
+      - type
+      additionalProperties: true
+      x-source-id: https://schema.beckn.io/GeoJSONGeometry/v2.0
+    Quantity:
+      description: Schema definition for Quantity in the Beckn Protocol v2.0.1
+      title: Quantity
+      type: object
+      properties:
+        maxQuantity:
+          description: Maximum quantity for this price
+          type: number
+          x-jsonld:
+            '@id': schema:Number
+          example: 100
+        minQuantity:
+          description: Minimum quantity for this price
+          type: number
+          x-jsonld:
+            '@id': schema:Number
+          example: 1
+        unitCode:
+          description: Unit code for the quoted price (e.g., KWH, MIN, H, MON)
+          type: string
+          x-jsonld:
+            '@id': schema:unitCode
+          example: KWH
+        unitQuantity:
+          description: Quantity of the unit
+          type: number
+          x-jsonld:
+            '@id': schema:Number
+          example: 1
+        unitText:
+          description: Unit for the quoted price (e.g., kWh, minute, hour, month)
+          type: string
+          x-jsonld:
+            '@id': schema:unitText
+          example: kWh
+      x-jsonld:
+        '@id': schema:QuantitativeValue
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Quantity/v2.0
+    Attributes:
+      description: JSON-LD aware container for domain-specific attributes of an Item. MUST include @context (URI) and @type
+        (compact or full IRI). Any additional properties are allowed and interpreted per the provided JSON-LD context.
+      title: Attributes
+      type: object
+      properties:
+        '@context':
+          description: Use case specific JSON-LD context URI
+          type: string
+          format: uri
+          example: https://example.org/schema/items/v1/ElectronicItem/schema-context.jsonld
+        '@type':
+          description: JSON-LD type defined within the context
+          type: string
+          example: ElectronicItem
+      required:
+      - '@context'
+      - '@type'
+      additionalProperties: true
+      x-source-id: https://schema.beckn.io/Attributes/v2.0
+    Credential:
+      description: A credential artifact that is either (a) a W3C Verifiable Credential (opaque JSON object) or (b) a document
+        attachment reference requiring manual/offline verification.
+      title: Credential
+      oneOf:
+      - title: W3C Verifiable Credential
+        description: A W3C Verifiable Credential as per the W3C VC Data Model. Treated as an opaque object at the schema layer.
+        type: object
+        additionalProperties: true
+      - title: Document Credential
+        description: A document attachment used as a credential.
+        $ref: '#/components/schemas/Document'
+      x-source-id: https://schema.beckn.io/Credential/v2.0
+    Skill:
+      description: Schema definition for Skill in the Beckn Protocol v2.0.1
+      title: Skill
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          enum:
+          - Skill
+        category:
+          $ref: '#/components/schemas/CategoryCode'
+        descriptor:
+          $ref: '#/components/schemas/Descriptor'
+        id:
+          type: string
+      required:
+      - '@context'
+      - '@type'
+      - id
+      - descriptor
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Skill/v2.0
+    Rating:
+      description: Aggregated rating information for an entity. Aligns with schema.org/AggregateRating semantics.
+      title: Rating
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: schema:AggregateRating
+        ratingValue:
+          description: Rating value (typically 0-5)
+          type: number
+          minimum: 0
+          maximum: 5
+          x-jsonld:
+            '@id': schema:ratingValue
+        ratingCount:
+          description: Number of ratings
+          type: integer
+          minimum: 0
+          x-jsonld:
+            '@id': schema:ratingCount
+        reviewText:
+          description: Optional textual review or comment
+          type: string
+          x-jsonld:
+            '@id': schema:reviewBody
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Rating/v2.0
+    State:
+      description: Schema definition for State in the Beckn Protocol v2.0.1
+      title: State
+      type: object
+      properties:
+        '@context':
+          description: CPD
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          description: TPD
+          type: string
+          default: beckn:State
+        descriptor:
+          $ref: '#/components/schemas/Descriptor'
+      required:
+      - '@context'
+      - '@type'
+      - descriptor
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/State/v2.0
+    FulfillmentStage:
+      description: Schema definition for FulfillmentStage in the Beckn Protocol v2.0.1
+      title: FulfillmentStage
+      type: object
+      properties:
+        '@context':
+          description: CPD
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: beckn:FulfillmentStageEndpoint
+        id:
+          description: A unique identifier for this stage of fulfillment
+          type: string
+        instructions:
+          description: A set of instructions to follow during this stage of fulfillment
+          type: array
+          items:
+            $ref: '#/components/schemas/Instruction'
+        preferences:
+          description: A extensible set of attributes that describe the fulfillment preferences
+          type: array
+          items:
+            $ref: '#/components/schemas/Attributes'
+        start:
+          description: An extensible set of attributes that describe the criteria required to start this stage of fulfillment
+          type: object
+          allOf:
+            $ref: '#/components/schemas/FulfillmentStageEndpoint'
+        end:
+          description: An extensible set of attributes that describe the criteria required to end this stage of fulfillment
+          allOf:
+            $ref: '#/components/schemas/FulfillmentStageEndpoint'
+        fulfillmentStageAttributes:
+          description: An extensible set of attributes that describe this stage of fulfillment
+          allOf:
+            $ref: '#/components/schemas/Attributes'
+      x-jsonld:
+        '@id': beckn:fulfillmentStage
+      required:
+      - '@context'
+      - '@type'
+      - id
+      - location
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/FulfillmentStage/v2.0
+    FulfillmentMode:
+      description: Describes the mode of fulfillment. This is an extensible container allowing domain-specific fulfillment
+        modes to be expressed via attributes.
+      title: FulfillmentMode
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: beckn:FulfillmentMode
+        id:
+          type: string
+        descriptor:
+          $ref: '#/components/schemas/Descriptor'
+        modeAttributes:
+          description: Domain-specific fulfillment mode attributes (e.g., delivery, pickup, reservation, digital)
+          allOf:
+          - $ref: '#/components/schemas/Attributes'
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/FulfillmentMode/v2.0
+    FulfillmentAgent:
+      description: The entity directly involved in fulfilling the order. It could be a person, an organization, a machine,
+        a software application, or an AI Agent.
+      title: FulfillmentAgent
+      allOf:
+      - type: object
+        additionalProperties: false
+        properties:
+          '@context':
+            description: CPD
+            type: string
+            format: uri
+            const: https://schema.beckn.io/
+          '@type':
+            type: string
+            const: beckn:Agent
+            x-jsonld:
+              '@id': schema:Thing
+          agentAttributes:
+            description: 'Attribute Pack reference for richer identity: # agent/identity.v1 (contact details: email, phone,
+              address) # agent/org-ids.v1 (LEI, GSTIN, ISIN, CUSIP…) # consumer/kyc.v1 (jurisdictional compliance fields)
+              # (accessibility needs, etc.)
+
+              '
+            $ref: '#/components/schemas/Attributes'
+        required:
+        - '@context'
+        - '@type'
+      - oneOf:
+        - type: object
+          additionalProperties: false
+          properties:
+            person:
+              $ref: '#/components/schemas/Person'
+          required:
+          - person
+        - type: object
+          additionalProperties: false
+          properties:
+            organization:
+              $ref: '#/components/schemas/Organization'
+          required:
+          - organization
+      x-source-id: https://schema.beckn.io/FulfillmentAgent/v2.0
+    Policy:
+      description: Schema definition for Policy in the Beckn Protocol v2.0.1
+      title: Policy
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          enum:
+          - Policy
+        descriptor:
+          description: Validity window for this policy version
+          allOf:
+          - $ref: '#/components/schemas/Descriptor'
+        id:
+          description: Identifier for the policy
+          type: string
+        policyType:
+          description: Type/kind of policy (extensible term)
+          type: string
+        validity:
+          description: Validity window for this policy version
+          allOf:
+          - $ref: '#/components/schemas/TimePeriod'
+        policyAttributes:
+          $ref: '#/components/schemas/Attributes'
+      required:
+      - '@context'
+      - '@type'
+      - id
+      - descriptor
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Policy/v2.0
+    Location:
+      description: A **place** represented by **GeoJSON geometry** (Point/Polygon/Multi*) and optional human-readable `address`.
+        This unifies all Beckn location fields into a single, widely-adopted representation (GeoJSON).
+      title: Location
+      type: object
+      properties:
+        '@type':
+          type: string
+          enum:
+          - Location
+        address:
+          description: Optional human-readable address for the same place/area.
+          oneOf:
+          - type: string
+          - $ref: '#/components/schemas/Address'
+        geo:
+          $ref: '#/components/schemas/GeoJSONGeometry'
+      required:
+      - geo
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Location/v2.0
+    Constraint:
+      description: Schema definition for Constraint in the Beckn Protocol v2.0.1
+      title: Constraint
+      type: object
+      properties:
+        '@context':
+          description: CPD
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          enum:
+          - Constraint
+        constraintType:
+          description: Type of constraint (extensible term)
+          type: string
+        id:
+          description: Identifier for the constraint
+          type: string
+        operator:
+          description: Comparator/operator (<=, >=, =, etc.)
+          type: string
+        unitCode:
+          description: Unit code (e.g., km, min)
+          type: string
+        validity:
+          $ref: '#/components/schemas/TimePeriod'
+        value:
+          description: Constraint value
+          type: number
+      required:
+      - '@context'
+      - '@type'
+      - id
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Constraint/v2.0
+    CategoryCode:
+      description: Schema definition for CategoryCode in the Beckn Protocol v2.0.1
+      title: CategoryCode
+      type: object
+      properties:
+        '@context':
+          description: CPD
+          type: string
+          format: uri
+          default: schema:CategoryCode
+        '@type':
+          description: Context-specific Type of the category code
+          type: string
+          default: schema:CategoryCode
+        schema:codeValue:
+          description: Category code value
+          type: string
+          example: electronics
+        schema:description:
+          description: Category description
+          type: string
+          example: Electronic devices and equipment
+        schema:name:
+          description: Category name
+          type: string
+          example: Electronics
+      required:
+      - '@type'
+      - schema:codeValue
+      x-source-id: https://schema.beckn.io/CategoryCode/v2.0
+    Provider:
+      description: Schema definition for Provider in the Beckn Protocol v2.0.1
+      title: Provider
+      type: object
+      properties:
+        '@context':
+          description: CPD
+          type: string
+          format: uri
+          default: https://schema.beckn.io/v2
+        '@type':
+          description: TPD
+          type: string
+          default: beckn:Provider
+        alerts:
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
+        descriptor:
+          $ref: '#/components/schemas/Descriptor'
+        id:
+          description: Unique identifier for the provider
+          type: string
+          example: tech-store-001
+        locations:
+          description: Physical locations where the provider operates
+          type: array
+          items:
+            $ref: '#/components/schemas/Location'
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/Policy'
+        providerAttributes:
+          $ref: '#/components/schemas/Attributes'
+        rateable:
+          description: Whether the provider can be rated by customers
+          type: boolean
+          example: true
+        rating:
+          $ref: '#/components/schemas/Rating'
+        validity:
+          $ref: '#/components/schemas/TimePeriod'
+      required:
+      - id
+      - descriptor
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Provider/v2.0
+    TimePeriod:
+      description: Time window with date-time precision for availability/validity
+      title: TimePeriod
+      type: object
+      properties:
+        '@type':
+          description: JSON-LD type for a date-time period
+          type: string
+          example: TimePeriod
+        schema:endDate:
+          description: End instant (exclusive or inclusive per domain semantics)
+          type: string
+          format: date-time
+          example: '2025-12-31T23:59:59Z'
+        schema:endTime:
+          description: End time of the time period
+          type: string
+          format: time
+          example: '22:00:00'
+        schema:startDate:
+          description: Start instant (inclusive)
+          type: string
+          format: date-time
+          example: '2025-01-27T09:00:00Z'
+        schema:startTime:
+          description: Start time of the time period
+          type: string
+          format: time
+          example: 09:00:00
+      required:
+      - '@type'
+      anyOf:
+      - required:
+        - schema:startDate
+      - required:
+        - schema:endDate
+      - required:
+        - schema:startTime
+        - schema:endTime
+      x-source-id: https://schema.beckn.io/TimePeriod/v2.0
+    AcceptedPaymentMethod:
+      description: Payment methods accepted by a payee
+      title: AcceptedPaymentMethod
+      type: array
+      items:
+        type: string
+        enum:
+        - UPI
+        - CREDIT_CARD
+        - DEBIT_CARD
+        - WALLET
+        - BANK_TRANSFER
+        - CASH
+        - APPLE_PAY
+      x-jsonld:
+        '@id': beckn:acceptedPaymentMethod
+      x-source-id: https://schema.beckn.io/AcceptedPaymentMethod/v2.0
+    FulfillmentStageEndpoint:
+      description: 'A stage boundary endpoint (entry or exit) within a fulfillment, such as pickup, handover, warehouse in/out,
+        border crossing, gate entry/exit, security check, etc. May require one or more proofs/permits/tokens/documents.
+
+        '
+      title: FulfillmentStageEndpoint
+      type: object
+      additionalProperties: false
+      properties:
+        '@context':
+          description: CPD
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: beckn:FulfillmentStageEndpoint
+        location:
+          $ref: '#/components/schemas/Location'
+        time:
+          $ref: '#/components/schemas/TimePeriod'
+        authorization:
+          type: array
+          description: 'One or more credentials required and/or issued at this endpoint. Includes machine-readable tokens
+            (QR/URL/OTP) and manual documents (IDs, permits).
+
+            '
+          items:
+            $ref: '#/components/schemas/FulfillmentStageAuthorization'
+      x-source-id: https://schema.beckn.io/FulfillmentStageEndpoint/v2.0
+    Instruction:
+      description: Schema definition for Instruction in the Beckn Protocol v2.0.1
+      title: Instruction
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          enum:
+          - Instruction
+        descriptor:
+          $ref: '#/components/schemas/Descriptor'
+        id:
+          type: string
+        validity:
+          $ref: '#/components/schemas/TimePeriod'
+      required:
+      - '@context'
+      - '@type'
+      - id
+      - descriptor
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Instruction/v2.0
+    Person:
+      description: A person (alive, deceased, or fictional). Modeled after schema.org/Person.
+      title: Person
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: schema:Person
+        id:
+          type: string
+          description: Unique identifier for the person
+          x-jsonld:
+            '@id': schema:identifier
+        name:
+          type: string
+          description: Full name of the person
+          x-jsonld:
+            '@id': schema:name
+        email:
+          type: string
+          format: email
+          description: Email address
+          x-jsonld:
+            '@id': schema:email
+        telephone:
+          type: string
+          description: Telephone number
+          x-jsonld:
+            '@id': schema:telephone
+        address:
+          description: Physical address
+          oneOf:
+          - type: string
+          - $ref: '#/components/schemas/Address'
+          x-jsonld:
+            '@id': schema:address
+        age:
+          type: integer
+          description: Age in years
+          minimum: 0
+          x-jsonld:
+            '@id': schema:age
+        knowsLanguage:
+          type: array
+          description: Languages known by the person (BCP-47 codes or language names)
+          items:
+            type: string
+          x-jsonld:
+            '@id': schema:knowsLanguage
+        worksFor:
+          description: Organization the person works for
+          allOf:
+          - $ref: '#/components/schemas/Organization'
+          x-jsonld:
+            '@id': schema:worksFor
+        credentials:
+          type: array
+          description: Credentials held by the person
+          items:
+            $ref: '#/components/schemas/Credential'
+          x-jsonld:
+            '@id': schema:hasCredential
+        skills:
+          type: array
+          description: Skills possessed by the person
+          items:
+            $ref: '#/components/schemas/Skill'
+          x-jsonld:
+            '@id': schema:hasSkill
+        personAttributes:
+          description: Extensible attribute pack for jurisdictional or domain-specific person properties
+          allOf:
+          - $ref: '#/components/schemas/Attributes'
+      required:
+      - '@context'
+      - '@type'
+      - id
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Person/v2.0
+    Organization:
+      description: An organization such as a company, non-profit, or governmental institution. Modeled after schema.org/Organization.
+      title: Organization
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: schema:Organization
+        id:
+          type: string
+          description: Unique identifier for the organization
+          x-jsonld:
+            '@id': schema:identifier
+        name:
+          type: string
+          description: Name of the organization
+          x-jsonld:
+            '@id': schema:name
+        email:
+          type: string
+          format: email
+          description: Email address
+          x-jsonld:
+            '@id': schema:email
+        telephone:
+          type: string
+          description: Telephone number
+          x-jsonld:
+            '@id': schema:telephone
+        address:
+          description: Physical address
+          oneOf:
+          - type: string
+          - $ref: '#/components/schemas/Address'
+          x-jsonld:
+            '@id': schema:address
+        credentials:
+          type: array
+          description: Credentials held by the organization
+          items:
+            $ref: '#/components/schemas/Credential'
+          x-jsonld:
+            '@id': schema:hasCredential
+        skills:
+          type: array
+          description: Skills or capabilities of the organization
+          items:
+            $ref: '#/components/schemas/Skill'
+          x-jsonld:
+            '@id': schema:hasSkill
+        organizationAttributes:
+          description: Extensible attribute pack for jurisdictional or domain-specific organization properties
+          allOf:
+          - $ref: '#/components/schemas/Attributes'
+      required:
+      - '@context'
+      - '@type'
+      - id
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Organization/v2.0
+    Address:
+      description: '**Postal address** aligned with schema.org `PostalAddress`. Use for human-readable addresses. Geometry
+        lives in `Location.geo` as GeoJSON.'
+      title: Address
+      type: object
+      properties:
+        addressCountry:
+          description: Country name or ISO-3166-1 alpha-2 code.
+          type: string
+          example: IN
+        addressLocality:
+          description: City/locality.
+          type: string
+          example: Bengaluru
+        addressRegion:
+          description: State/region/province.
+          type: string
+          example: Karnataka
+        extendedAddress:
+          description: Address extension (apt/suite/floor, C/O).
+          type: string
+          example: Apt 4B
+        postalCode:
+          description: Postal/ZIP code.
+          type: string
+          example: '560001'
+        streetAddress:
+          description: Street address (building name/number and street).
+          type: string
+          example: 123 Tech Street
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Address/v2.0
+    Alert:
+      description: Schema definition for Alert in the Beckn Protocol v2.0.1
+      title: Alert
+      type: object
+      properties:
+        '@context':
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          enum:
+          - Alert
+        affectedEntities:
+          description: IDs of entities affected (route/order/fulfillment/etc.)
+          type: array
+          items:
+            type: string
+        descriptor:
+          $ref: '#/components/schemas/Descriptor'
+        id:
+          type: string
+        severity:
+          type: string
+        validity:
+          $ref: '#/components/schemas/TimePeriod'
+      required:
+      - '@context'
+      - '@type'
+      - id
+      - descriptor
+      additionalProperties: false
+      x-source-id: https://schema.beckn.io/Alert/v2.0
+    FulfillmentStageAuthorization:
+      description: 'A credential/document/proof relevant to authorization at a fulfillment stage endpoint. This may be a token
+        to be verified (QR/OTP/URL) or a document to be inspected manually.
+
+        '
+      title: FulfillmentStageAuthorization
+      type: object
+      additionalProperties: false
+      required:
+      - purpose
+      - requirement
+      - status
+      properties:
+        '@context':
+          description: CPD
+          type: string
+          format: uri
+          const: https://schema.beckn.io/
+        '@type':
+          type: string
+          default: beckn:FulfillmentStageAuthorization
+        mediaFiles:
+          description: Media files required to enter or exit this fulfillment stage. The could be images of delivered packages,
+            recorded video proof of installation, etc
+          type: array
+          items:
+            $ref: '#/components/schemas/MediaFile'
+        docs:
+          description: Documents required to enter or exit this fulfillment stage. The could be entry tickets, boarding passes,
+            waybill, permits, certificates, credentials, etc
+          type: array
+          items:
+            allOf:
+            - $ref: '#/components/schemas/Document'
+        authToken:
+          type: string
+          description: A human readable string that needs to be provided to enter or exit this fulfillment stage. Like an
+            OTP
+      x-source-id: https://schema.beckn.io/FulfillmentStageAuthorization/v2.0
+    DiscoverRequest:
+      title: DiscoverRequest
+      description: 'Beckn Protocol request envelope for the `beckn/discover` endpoint.
+
+
+        `context.action` MUST be set to `beckn/discover`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/discover`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/discover`.
+          type: object
+          required:
+          - intent
+          properties:
+            intent:
+              allOf:
+              - $ref: '#/components/schemas/Intent'
+    OnDiscoverRequest:
+      title: OnDiscoverRequest
+      description: 'Beckn Protocol request envelope for the `beckn/on_discover` endpoint.
+
+
+        `context.action` MUST be set to `beckn/on_discover`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/on_discover`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/on_discover`.
+          type: object
+          required:
+          - catalogs
+          properties:
+            catalogs:
+              type: array
+              items:
+                $ref: '#/components/schemas/Catalog'
+    SelectRequest:
+      title: SelectRequest
+      description: 'Beckn Protocol request envelope for the `beckn/select` endpoint.
+
+
+        `context.action` MUST be set to `beckn/select`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/select`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/select`.
+          type: object
+          required:
+          - contract
+          properties:
+            contract:
+              allOf:
+              - $ref: '#/components/schemas/Contract'
+    OnSelectRequest:
+      title: OnSelectRequest
+      description: 'Beckn Protocol request envelope for the `beckn/on_select` endpoint.
+
+
+        `context.action` MUST be set to `beckn/on_select`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/on_select`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/on_select`.
+          type: object
+          required:
+          - contract
+          properties:
+            contract:
+              allOf:
+              - $ref: '#/components/schemas/Contract'
+    InitRequest:
+      title: InitRequest
+      description: 'Beckn Protocol request envelope for the `beckn/init` endpoint.
+
+
+        `context.action` MUST be set to `beckn/init`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/init`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/init`.
+          type: object
+          required:
+          - contract
+          properties:
+            contract:
+              allOf:
+              - $ref: '#/components/schemas/Contract'
+    OnInitRequest:
+      title: OnInitRequest
+      description: 'Beckn Protocol request envelope for the `beckn/on_init` endpoint.
+
+
+        `context.action` MUST be set to `beckn/on_init`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/on_init`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/on_init`.
+          type: object
+          required:
+          - contract
+          properties:
+            contract:
+              allOf:
+              - $ref: '#/components/schemas/Contract'
+    ConfirmRequest:
+      title: ConfirmRequest
+      description: 'Beckn Protocol request envelope for the `beckn/confirm` endpoint.
+
+
+        `context.action` MUST be set to `beckn/confirm`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/confirm`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/confirm`.
+          type: object
+          required:
+          - contract
+          properties:
+            contract:
+              allOf:
+              - $ref: '#/components/schemas/Contract'
+    OnConfirmRequest:
+      title: OnConfirmRequest
+      description: 'Beckn Protocol request envelope for the `beckn/on_confirm` endpoint.
+
+
+        `context.action` MUST be set to `beckn/on_confirm`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/on_confirm`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/on_confirm`.
+          type: object
+          required:
+          - contract
+          properties:
+            contract:
+              allOf:
+              - $ref: '#/components/schemas/Contract'
+    StatusRequest:
+      title: StatusRequest
+      description: 'Beckn Protocol request envelope for the `beckn/status` endpoint.
+
+
+        `context.action` MUST be set to `beckn/status`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/status`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/status`.
+          type: object
+          required:
+          - order
+          properties:
+            order:
+              type: object
+              description: Minimal contract/order reference for the status query.
+              properties:
+                id:
+                  description: Identifier of the contract/order whose status is being queried.
+                  type: string
+              required:
+              - id
+    OnStatusRequest:
+      title: OnStatusRequest
+      description: 'Beckn Protocol request envelope for the `beckn/on_status` endpoint.
+
+
+        `context.action` MUST be set to `beckn/on_status`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/on_status`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/on_status`.
+          type: object
+          required:
+          - contract
+          properties:
+            contract:
+              allOf:
+              - $ref: '#/components/schemas/Contract'
+    TrackRequest:
+      title: TrackRequest
+      description: 'Beckn Protocol request envelope for the `beckn/track` endpoint.
+
+
+        `context.action` MUST be set to `beckn/track`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/track`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/track`.
+          type: object
+          required:
+          - tracking
+          properties:
+            tracking:
+              allOf:
+              - $ref: '#/components/schemas/TrackingRequest'
+    OnTrackRequest:
+      title: OnTrackRequest
+      description: 'Beckn Protocol request envelope for the `beckn/on_track` endpoint.
+
+
+        `context.action` MUST be set to `beckn/on_track`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/on_track`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/on_track`.
+          type: object
+          required:
+          - tracking
+          properties:
+            tracking:
+              allOf:
+              - $ref: '#/components/schemas/Tracking'
+    UpdateRequest:
+      title: UpdateRequest
+      description: 'Beckn Protocol request envelope for the `beckn/update` endpoint.
+
+
+        `context.action` MUST be set to `beckn/update`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/update`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/update`.
+          type: object
+          required:
+          - contract
+          properties:
+            contract:
+              allOf:
+              - $ref: '#/components/schemas/Contract'
+    OnUpdateRequest:
+      title: OnUpdateRequest
+      description: 'Beckn Protocol request envelope for the `beckn/on_update` endpoint.
+
+
+        `context.action` MUST be set to `beckn/on_update`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/on_update`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/on_update`.
+          type: object
+          required:
+          - contract
+          properties:
+            contract:
+              allOf:
+              - $ref: '#/components/schemas/Contract'
+    CancelRequest:
+      title: CancelRequest
+      description: 'Beckn Protocol request envelope for the `beckn/cancel` endpoint.
+
+
+        `context.action` MUST be set to `beckn/cancel`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/cancel`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/cancel`.
+          type: object
+          required:
+          - contract
+          properties:
+            contract:
+              allOf:
+              - $ref: '#/components/schemas/Contract'
+    OnCancelRequest:
+      title: OnCancelRequest
+      description: 'Beckn Protocol request envelope for the `beckn/on_cancel` endpoint.
+
+
+        `context.action` MUST be set to `beckn/on_cancel`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/on_cancel`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/on_cancel`.
+          type: object
+          required:
+          - contract
+          properties:
+            contract:
+              allOf:
+              - $ref: '#/components/schemas/Contract'
+    RateRequest:
+      title: RateRequest
+      description: 'Beckn Protocol request envelope for the `beckn/rate` endpoint.
+
+
+        `context.action` MUST be set to `beckn/rate`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/rate`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/rate`.
+          type: object
+          required:
+          - ratingInputs
+          properties:
+            ratingInputs:
+              type: array
+              items:
+                $ref: '#/components/schemas/RatingInput'
+    OnRateRequest:
+      title: OnRateRequest
+      description: 'Beckn Protocol request envelope for the `beckn/on_rate` endpoint.
+
+
+        `context.action` MUST be set to `beckn/on_rate`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/on_rate`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/on_rate`.
+          type: object
+          required:
+          - ratingForms
+          properties:
+            ratingForms:
+              type: array
+              items:
+                $ref: '#/components/schemas/RatingForm'
+    SupportActionRequest:
+      title: SupportActionRequest
+      description: 'Beckn Protocol request envelope for the `beckn/support` endpoint.
+
+
+        `context.action` MUST be set to `beckn/support`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/support`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/support`.
+          type: object
+          required:
+          - supportRequest
+          properties:
+            supportRequest:
+              allOf:
+              - $ref: '#/components/schemas/SupportRequest'
+    OnSupportRequest:
+      title: OnSupportRequest
+      description: 'Beckn Protocol request envelope for the `beckn/on_support` endpoint.
+
+
+        `context.action` MUST be set to `beckn/on_support`.'
+      type: object
+      required:
+      - context
+      - message
+      additionalProperties: false
+      properties:
+        context:
+          description: Transaction context. `context.action` MUST be `beckn/on_support`.
+          allOf:
+          - $ref: '#/components/schemas/Context'
+        message:
+          description: Action-specific payload for `beckn/on_support`.
+          type: object
+          required:
+          - supportInfo
+          properties:
+            supportInfo:
+              allOf:
+              - $ref: '#/components/schemas/SupportInfo'
   parameters:
     AuthorizationHeader:
       name: Authorization
       in: header
       required: true
-      description: Beckn Signature authentication header. See `#/components/schemas/Signature` for the expected structure.
-      schema:
-        $ref: "#/components/schemas/Signature"
+      description: 'Beckn Signature authentication header (POST endpoints and GET Body Mode).
 
+        See `#/components/schemas/Signature` for the expected format.
+
+        '
+      schema:
+        $ref: '#/components/schemas/Signature'
     AuthorizationQuery:
       name: Authorization
       in: query
       required: false
-      description: Beckn Signature passed as a query parameter (GET Query Mode only). See `#/components/schemas/Signature` for the expected structure.
-      schema:
-        $ref: "#/components/schemas/Signature"
+      description: 'Beckn Signature passed as a query parameter (GET Query Mode only).
 
+        Mutually exclusive with the `Authorization` header and the request body.
+
+        '
+      schema:
+        $ref: '#/components/schemas/Signature'
     RequestActionQuery:
       name: RequestAction
       in: query
       required: false
-      description: Beckn action payload passed as a query parameter (GET Query Mode only). See `#/components/schemas/BecknAction` for the expected structure.
+      description: 'Beckn action payload passed as a URL-encoded query parameter (GET Query Mode only).
 
+        The value is a JSON-serialised `BecknAction`. Mutually exclusive with the request body.
+
+        '
   responses:
     Ack:
       description: Receipt confirmed; signature valid; asynchronous callback will follow.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Ack"
-
+            $ref: '#/components/schemas/Ack'
     AckNoCallback:
-      description: Request received but no callback will follow (e.g. agents not found, inventory unavailable, store closed).
+      description: Request received but no callback will follow (e.g. agents not found, inventory unavailable).
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/AckNoCallback"
-
+            $ref: '#/components/schemas/AckNoCallback'
     NackBadRequest:
       description: Malformed or invalid request; the server could not parse or validate the payload.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/NackBadRequest"
-
+            $ref: '#/components/schemas/NackBadRequest'
     NackUnauthorized:
       description: Invalid or missing authentication credentials; signature could not be verified.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/NackUnauthorized"
-
+            $ref: '#/components/schemas/NackUnauthorized'
     ServerError:
-      description: Internal failure on the network participant's platform; the request could not be processed.
+      description: Internal failure on the network participant's platform.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ServerError"
+            $ref: '#/components/schemas/ServerError'

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -1,0 +1,369 @@
+openapi: 3.1.1
+info:
+  title: Beckn Protocol API Specification Version 2
+  description: |
+    The API specification of Beckn Protocol covering the known interaction domains of a Beckn-enabled network. Current domains include Discovery, Ordering, Fulfillment, and Post-Fulfillment. The protocol is being actively extended to cover additional domains including Reconciliation & Settlement, Observability, Reputation Ledger, and Issue & Grievance Management.
+  version: 2.0.0
+  contact:
+    name: Beckn Protocol
+    url: https://beckn.io
+  license:
+    name: CC-BY-NC-SA 4.0 International
+    url: https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en
+
+paths:
+  /beckn/{becknEndpoint}:
+    get:
+      summary: Dispatch a Beckn protocol action on an HTTP GET endpoint (Body Mode or Query Mode)
+      description: |
+        Universal endpoint for dispatching any Beckn protocol action across a Beckn-enabled network. The `{becknEndpoint}` path parameter identifies the specific operation being performed within any supported Beckn interaction domain.
+
+        This endpoint supports two mutually exclusive modes:
+
+        **Body Mode** — The action payload is sent as a JSON request body (`BecknAction`) and the Beckn Signature is transmitted in the `Authorization` header:
+        `GET /beckn/{becknEndpoint}` with `Authorization: {Signature}` header and `BecknAction` body.
+        Used for server-to-server interactions where the caller has a registered callback endpoint and expects an asynchronous callback in return.
+
+        **Query Mode** — The action payload and signature are both expressed as URL query parameters, making the entire request a self-contained URL suitable for QR codes, deep links, bookmarkable pages, frontend UIs, IoT/embedded clients, and browser-triggered interactions:
+        `GET /beckn/{becknEndpoint}?Authorization={Signature}&RequestAction={RequestActionQuery}`
+        In Query Mode, the caller MUST NOT expect a callback. The server acknowledges receipt with an `Ack` (HTTP 200) but will not send an asynchronous callback to the caller. Query Mode is designed for stateless, one-way interactions where the originating client (e.g. a browser or QR code scanner) has no registered callback endpoint.
+
+        These two modes are mutually exclusive. If `Authorization` and `RequestAction` are present as query parameters, the request body MUST be absent and the `Authorization` header MUST be absent. If the request body is present, both query parameters MUST be absent.
+
+        This endpoint may be implemented by any Beckn Network Participant — including Beckn Application Platforms (BAPs), Beckn Provider Platforms (BPPs), Catalog Discovery Services, Catalog Publishing Services, and Registries (which follow the DeDi — Decentralized Directory — protocol for network participant lookup and public key resolution). Each participant may selectively support a subset of actions appropriate to their role.
+
+        The server responds synchronously with an `Ack` (HTTP 200) confirming receipt and successful signature validation, indicating that an asynchronous callback will follow (Body Mode). An `AckNoCallback` (HTTP 409) indicates the request was received but no callback will follow due to a business constraint. A `NackBadRequest` (HTTP 400), `NackUnauthorized` (HTTP 401), or `ServerError` (HTTP 500) indicates that the request could not be accepted.
+      parameters:
+        - name: becknEndpoint
+          in: path
+          required: true
+          schema:
+            $ref: "https://schema.beckn.io/BecknEndpoint/v2.0"
+        # Body Mode — Authorization in header (mutually exclusive with Query Mode parameters)
+        - name: Authorization
+          in: header
+          required: false
+          description: Beckn Signature authentication header (Body Mode only). See `#/components/schemas/Signature` for the expected structure.
+          schema:
+            $ref: "#/components/schemas/Signature"
+        # Query Mode — Authorization and RequestAction both in query string (mutually exclusive with Body Mode)
+        - $ref: "#/components/parameters/AuthorizationQuery"
+        - $ref: "#/components/parameters/RequestActionQuery"
+      requestBody:
+        required: false
+        description: Body Mode only — MUST be absent when query parameters are used.
+        content:
+          application/json:
+            schema:
+              $ref: "https://schema.beckn.io/BecknAction/v2.0"
+      responses:
+        "200":
+          $ref: "#/components/responses/Ack"
+        "400":
+          $ref: "#/components/responses/NackBadRequest"
+        "401":
+          $ref: "#/components/responses/NackUnauthorized"
+        "409":
+          $ref: "#/components/responses/AckNoCallback"
+        "500":
+          $ref: "#/components/responses/ServerError"
+    post:
+      summary: Dispatch a Beckn protocol action on an HTTP POST endpoint
+      description: |
+        Universal endpoint for dispatching any Beckn protocol action across a Beckn-enabled network. The `{action}` path parameter identifies the specific operation being performed within any supported Beckn interaction domain.
+
+        The request body MUST conform to `BecknAction` — the unified schema for all Beckn requests and callbacks. The `action` value in the path (and in `context.action`) determines which message content schema applies: forward actions (e.g. `beckn/discover`, `beckn/select`, `beckn/init`, `beckn/confirm`) carry a request payload, while callback actions (e.g. `beckn/on_discover`, `beckn/on_select`, `beckn/on_init`, `beckn/on_confirm`) carry a callback payload. `BecknAction` validates message content for all known actions via `if/then` dispatch on `context.action`.
+
+        This endpoint may be implemented by any Beckn Network Participant — including Beckn Application Platforms (BAPs), Beckn Provider Platforms (BPPs), Catalog Discovery Services, Catalog Publishing Services, and Registries (which follow the DeDi — Decentralized Directory — protocol for network participant lookup and public key resolution). Each participant may selectively support a subset of actions appropriate to their role.
+
+        All requests MUST be authenticated using a valid Beckn Signature transmitted in the `Authorization` header. The receiver validates the signature against the sender's public key resolved from the Beckn Registry.
+
+        The server responds synchronously with an `Ack` (HTTP 200) confirming receipt and successful signature validation, indicating that an asynchronous callback will follow. An `AckNoCallback` (HTTP 409) indicates the request was received but no callback will follow due to a business constraint (e.g. agents not found, inventory unavailable, store closed). A `NackBadRequest` (HTTP 400), `NackUnauthorized` (HTTP 401), or `ServerError` (HTTP 500) indicates that the request could not be accepted.
+      parameters:
+        - $ref: "#/components/parameters/AuthorizationHeader"
+        - name: becknEndpoint
+          in: path
+          required: true
+          schema:
+            $ref: "https://schema.beckn.io/BecknEndpoint/v2.0"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "https://schema.beckn.io/BecknAction/v2.0"
+      responses:
+        "200":
+          $ref: "#/components/responses/Ack"
+        "400":
+          $ref: "#/components/responses/NackBadRequest"
+        "401":
+          $ref: "#/components/responses/NackUnauthorized"
+        "409":
+          $ref: "#/components/responses/AckNoCallback"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+components:
+  schemas:
+    Ack:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - ACK
+            - NACK
+        signature:
+          $ref: "#/components/schemas/CounterSignature"
+      required:
+        - status
+        - signature
+
+    AckNoCallback:
+      allOf:
+        - $ref: "#/components/schemas/Ack"
+        - properties:
+            error:
+
+    AsyncError:
+      description: Container schema for errors returned during a callback
+      allOf:
+        - $ref: "#/components/schemas/Error"
+        - properties:
+            "@context":
+              type: string
+              default: "https://schema.beckn.io/"
+            "@type":
+              type: string
+              default: "AsyncError"
+          additionalProperties: true
+
+    # Delegated to https://schema.beckn.io/BecknAction/v2.0
+    # BecknAction is the unified action envelope for all Beckn requests and callbacks.
+    # context.action (a BecknEndpoint) determines which message schema applies.
+    # message content is validated via allOf if/then dispatch.
+    # Supersedes RequestContainer and CallbackContainer.
+    BecknAction:
+      $ref: "https://schema.beckn.io/BecknAction/v2.0"
+
+    # Delegated to https://schema.beckn.io/BecknEndpoint/v2.0
+    # Kept as a component alias for backward compatibility.
+    BecknEndpoint:
+      $ref: "https://schema.beckn.io/BecknEndpoint/v2.0"
+
+    # DEPRECATED — superseded by BecknAction.
+    # Kept as a component alias for backward compatibility.
+    CallbackContainer:
+      $ref: "https://schema.beckn.io/BecknAction/v2.0"
+
+    # Delegated to https://schema.beckn.io/Context/v2.0
+    # Kept as a component alias for backward compatibility.
+    Context:
+      $ref: "https://schema.beckn.io/Context/v2.0"
+
+    CounterSignature:
+      title: Beckn HTTP Counter-Signature
+      description: |
+        A signed receipt transmitted in the synchronous `Ack` response body, proving that the receiver authenticated, received, and processed the inbound request. It is the schema realisation of the Signed Receipt of Receipt concept proposed in [Issue #69 — Strengthening Non-Repudiation and Causality in Beckn Transactions](https://github.com/beckn/protocol-specifications-v2/issues/69).
+
+        `CounterSignature` shares the same wire format as `Signature` (see `#/components/schemas/Signature`) but differs in three important ways:
+
+        | Aspect | `Signature` | `CounterSignature` |
+        |---|---|---|
+        | **Signer** | Request sender (BAP/BPP) | Response receiver (BPP/BAP) |
+        | **Transmitted in** | Inbound `Authorization` header | `Ack.signature` field in the synchronous HTTP response body |
+        | **`digest`** | BLAKE2b-512 of the **inbound request** body | BLAKE2b-512 of the **Ack response** body |
+        | **`(request-digest)`** | Not present | MUST be present — BLAKE2b-512 of the **inbound request** body |
+        | **`(message-id)`** | Not present | MUST be present — the `messageId` from the inbound request `Context` |
+        | **`headers`** | `"(created) (expires) digest"` | `"(created) (expires) digest (request-digest) (message-id)"` |
+
+        **Signing string for `CounterSignature`:**
+        ```
+        (created): {unixTimestamp}
+        (expires): {unixTimestamp}
+        digest: BLAKE-512={base64DigestOfAckBody}
+        (request-digest): BLAKE-512={base64DigestOfInboundRequestBody}
+        (message-id): {messageId}
+        ```
+
+        **Format:**
+        ```
+        Signature keyId="{subscriberId}|{uniqueKeyId}|{algorithm}",algorithm="{algorithm}",created="{unixTimestamp}",expires="{unixTimestamp}",headers="(created) (expires) digest (request-digest) (message-id)",signature="{base64Signature}"
+        ```
+
+        The verifier (the original sender of the request) MUST:
+        1. Recompute the BLAKE2b-512 digest of the Ack body and verify it matches `digest`.
+        2. Recompute the BLAKE2b-512 digest of their own request body and verify it matches `(request-digest)`.
+        3. Verify that `(message-id)` matches the `messageId` they sent in their request `Context`.
+        4. Resolve the receiver's public key from the registry using the `keyId` and verify the Ed25519 signature.
+      allOf:
+        - $ref: "#/components/schemas/Signature"
+      example: 'Signature keyId="example-bpp.com|74b43deb-236e-4498-8f5a-ca75d6c67b9d|ed25519",algorithm="ed25519",created="1641287900",expires="1641291500",headers="(created) (expires) digest (request-digest) (message-id)",signature="mX3sHA+9gileOkXYJXh4Jg8tK0gEEMbf9yCPnFpbldhrAY+NErqL9WD+Vav7TE5tyVXGXBle9ONZi2W7o144eQ=="'
+
+    Error:
+      description: Container schema for errors
+      type: object
+      properties:
+        errorCode:
+          type: string
+        errorMessage:
+          type: string
+
+    InReplyTo:
+      title: In-Reply-To Reference
+      description: |
+        A cryptographic binding that ties an asynchronous `on_<action>` callback to the specific inbound request that triggered it. Implements [Issue #69 Proposal #1 — Cryptographic Request–Response Binding](https://github.com/beckn/protocol-specifications-v2/issues/69).
+
+        Including `inReplyTo` in a callback allows the receiver (typically the BAP) to verify that the callback was produced in direct response to a specific earlier request, establishing **bilateral non-repudiation for the asynchronous leg** of a Beckn interaction. It is strictly **conversational** — it links a callback to its parent within the same transaction and MUST NOT be used to link across transaction boundaries (use `context.lineage` for cross-transaction causality).
+
+        **Verification steps for the recipient of the callback:**
+        1. Recompute the BLAKE2b-512 digest of the original request body and compare it to `digest`.
+        2. Confirm that `messageId` matches the `messageId` from the original request `Context`.
+
+        Together, these two checks prove that the callback sender received **exactly the request bytes** that were originally sent.
+      type: object
+      properties:
+        messageId:
+          description: The `messageId` of the parent request from its `Context`. Enables correlation between the async callback and the originating request.
+          type: string
+          format: uuid
+        digest:
+          description: |
+            BLAKE2b-512 hash of the parent request body bytes, encoded in Base64 and prefixed with the algorithm identifier.
+
+            Format: `BLAKE-512={base64EncodedHash}`
+
+            Example: `BLAKE-512=b6lf6lRgOweajukcvcLsagQ2T60+85kRh/Rd2bdS+TG/5ALebOEgDJfyCrre/1+BMu5nA94o4DT3pTFXuUg7sw==`
+          type: string
+          pattern: "^BLAKE-512=[A-Za-z0-9+/]+=*$"
+      required:
+        - messageId
+        - digest
+
+    # Delegated to https://schema.beckn.io/LineageEntry/v2.0
+    # Kept as a component alias for backward compatibility.
+    LineageEntry:
+      $ref: "https://schema.beckn.io/LineageEntry/v2.0"
+
+    # Delegated to https://schema.beckn.io/Message/v2.0
+    # Kept as a component alias for backward compatibility.
+    Message:
+      $ref: "https://schema.beckn.io/Message/v2.0"
+
+    NackBadRequest:
+      allOf:
+        - $ref: "#/components/schemas/Ack"
+        - properties:
+            status:
+              type: string
+              const: NACK
+            error:
+              $ref: "#/components/schemas/Error"
+
+    NackUnauthorized:
+      allOf:
+        - $ref: "#/components/schemas/Ack"
+        - properties:
+            status:
+              type: string
+              const: NACK
+            error:
+              $ref: "#/components/schemas/Error"
+
+    # DEPRECATED — superseded by BecknAction.
+    # Kept as a component alias for backward compatibility.
+    RequestContainer:
+      $ref: "https://schema.beckn.io/BecknAction/v2.0"
+
+    ServerError:
+      description: Internal server error returned as a response to a Beckn API call
+      type: object
+
+    Signature:
+      title: Beckn HTTP Signature
+      description: |
+        A digitally signed authentication credential transmitted in the HTTP `Authorization` header (or `X-Gateway-Authorization` for Beckn Gateways). The value follows the HTTP Signature scheme defined in [draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12) and as profiled by [BECKN-006](https://github.com/beckn/protocol-specifications/blob/master/docs/BECKN-006-Signing-Beckn-APIs-In-HTTP-Draft-01.md).
+
+        **Format:**
+        ```
+        Signature keyId="{subscriberId}|{uniqueKeyId}|{algorithm}",algorithm="{algorithm}",created="{unixTimestamp}",expires="{unixTimestamp}",headers="{signedHeaders}",signature="{base64Signature}"
+        ```
+
+        **Attributes:**
+
+        | Attribute   | Description |
+        |-------------|-------------|
+        | `keyId`     | Composite key identifier with three pipe-delimited (`\|`) components: `{subscriberId}` (typically the FQDN of the subscriber), `{uniqueKeyId}` (UUID assigned by the registry when the subscriber key entry was created), and `{algorithm}` (the signing algorithm, e.g. `ed25519`). |
+        | `algorithm` | The signing algorithm. MUST be `ed25519` as per current Beckn specification. |
+        | `created`   | Unix timestamp (integer) indicating when the signature was created. A signature whose `created` value is in the future MUST NOT be processed. |
+        | `expires`   | Unix timestamp (integer) indicating when the signature expires. A signature whose `expires` value is in the past MUST NOT be processed. The difference between `expires` and `created` SHOULD equal the TTL of the request. The `expires` value MUST NOT exceed the expiry of the signing key registered in the registry. |
+        | `headers`   | Space-separated list of HTTP header names and pseudo-headers whose values are included in the signing string. MUST include `(created)`, `(expires)`, and `digest`. |
+        | `signature` | Base64-encoded Ed25519 signature over the signing string. The signing string is formed by concatenating `(created): {value}\n(expires): {value}\ndigest: BLAKE-512={digest}`, where the digest is a BLAKE2b-512 hash of the request body encoded in Base64. |
+
+        **Example:**
+        ```
+        Signature keyId="example-bap.com|ae3ea24b-cfec-495e-81f8-044aaef164ac|ed25519",algorithm="ed25519",created="1641287875",expires="1641291475",headers="(created) (expires) digest",signature="cjbhP0PFyrlSCNszJM1F/YmHDVAWsZqJUPzojnE/7TJU3fJ/rmIlgaUHEr5E0/2PIyf0tpSnWtT6cyNNlpmoAQ=="
+        ```
+      type: string
+      pattern: '^Signature keyId="[^|"]+\|[^|"]+\|[^"]+",algorithm="[^"]+",created="\d+",expires="\d+",headers="[^"]+",signature="[A-Za-z0-9+/]+=*"$'
+      example: 'Signature keyId="example-bap.com|ae3ea24b-cfec-495e-81f8-044aaef164ac|ed25519",algorithm="ed25519",created="1641287875",expires="1641291475",headers="(created) (expires) digest",signature="cjbhP0PFyrlSCNszJM1F/YmHDVAWsZqJUPzojnE/7TJU3fJ/rmIlgaUHEr5E0/2PIyf0tpSnWtT6cyNNlpmoAQ=="'
+
+  parameters:
+    AuthorizationHeader:
+      name: Authorization
+      in: header
+      required: true
+      description: Beckn Signature authentication header. See `#/components/schemas/Signature` for the expected structure.
+      schema:
+        $ref: "#/components/schemas/Signature"
+
+    AuthorizationQuery:
+      name: Authorization
+      in: query
+      required: false
+      description: Beckn Signature passed as a query parameter (GET Query Mode only). See `#/components/schemas/Signature` for the expected structure.
+      schema:
+        $ref: "#/components/schemas/Signature"
+
+    RequestActionQuery:
+      name: RequestAction
+      in: query
+      required: false
+      description: Beckn action payload passed as a query parameter (GET Query Mode only). See `#/components/schemas/BecknAction` for the expected structure.
+
+  responses:
+    Ack:
+      description: Receipt confirmed; signature valid; asynchronous callback will follow.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Ack"
+
+    AckNoCallback:
+      description: Request received but no callback will follow (e.g. agents not found, inventory unavailable, store closed).
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AckNoCallback"
+
+    NackBadRequest:
+      description: Malformed or invalid request; the server could not parse or validate the payload.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/NackBadRequest"
+
+    NackUnauthorized:
+      description: Invalid or missing authentication credentials; signature could not be verified.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/NackUnauthorized"
+
+    ServerError:
+      description: Internal failure on the network participant's platform; the request could not be processed.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ServerError"

--- a/api/v2.0.0/components/io/core.yaml
+++ b/api/v2.0.0/components/io/core.yaml
@@ -1,0 +1,121 @@
+openapi: 3.1.1
+info:
+  title: Beckn Protocol API — Abstract IO Specification
+  description: |
+    The abstract transport-layer IO specification for Beckn Protocol v2.0.
+
+    This is the **source of truth** for the protocol transport layer. It describes
+    a single generic endpoint `/beckn/{becknEndpoint}` that handles all Beckn
+    protocol actions. The `{becknEndpoint}` path parameter identifies the specific
+    operation; the request body (`BecknAction`) carries the action payload.
+
+    This file is an input to the generator script (`scripts/generate_endpoints.py`)
+    which produces `api/v2.0.0/beckn.yaml` — a fully resolved, concrete OpenAPI
+    specification with one path per known Beckn endpoint.
+
+    **Do not edit `api/v2.0.0/beckn.yaml` directly — edit this file and re-run
+    the generator.**
+  version: 2.0.0
+  contact:
+    name: Beckn Protocol
+    url: https://beckn.io
+  license:
+    name: CC-BY-NC-SA 4.0 International
+    url: https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en
+
+paths:
+  /beckn/{becknEndpoint}:
+    get:
+      summary: Dispatch a Beckn protocol action on an HTTP GET endpoint (Body Mode or Query Mode)
+      description: |
+        Universal endpoint for dispatching any Beckn protocol action across a Beckn-enabled network. The `{becknEndpoint}` path parameter identifies the specific operation being performed within any supported Beckn interaction domain.
+
+        This endpoint supports two mutually exclusive modes:
+
+        **Body Mode** — The action payload is sent as a JSON request body (`BecknAction`) and the Beckn Signature is transmitted in the `Authorization` header:
+        `GET /beckn/{becknEndpoint}` with `Authorization: {Signature}` header and `BecknAction` body.
+        Used for server-to-server interactions where the caller has a registered callback endpoint and expects an asynchronous callback in return.
+
+        **Query Mode** — The action payload and signature are both expressed as URL query parameters, making the entire request a self-contained URL suitable for QR codes, deep links, bookmarkable pages, frontend UIs, IoT/embedded clients, and browser-triggered interactions:
+        `GET /beckn/{becknEndpoint}?Authorization={Signature}&RequestAction={RequestActionQuery}`
+        In Query Mode, the caller MUST NOT expect a callback. The server acknowledges receipt with an `Ack` (HTTP 200) but will not send an asynchronous callback to the caller. Query Mode is designed for stateless, one-way interactions where the originating client (e.g. a browser or QR code scanner) has no registered callback endpoint.
+
+        These two modes are mutually exclusive. If `Authorization` and `RequestAction` are present as query parameters, the request body MUST be absent and the `Authorization` header MUST be absent. If the request body is present, both query parameters MUST be absent.
+
+        This endpoint may be implemented by any Beckn Network Participant — including Beckn Application Platforms (BAPs), Beckn Provider Platforms (BPPs), Catalog Discovery Services, Catalog Publishing Services, and Registries (which follow the DeDi — Decentralized Directory — protocol for network participant lookup and public key resolution). Each participant may selectively support a subset of actions appropriate to their role.
+
+        The server responds synchronously with an `Ack` (HTTP 200) confirming receipt and successful signature validation, indicating that an asynchronous callback will follow (Body Mode). An `AckNoCallback` (HTTP 409) indicates the request was received but no callback will follow due to a business constraint. A `NackBadRequest` (HTTP 400), `NackUnauthorized` (HTTP 401), or `ServerError` (HTTP 500) indicates that the request could not be accepted.
+      parameters:
+        - name: becknEndpoint
+          in: path
+          required: true
+          schema:
+            $ref: "https://schema.beckn.io/BecknEndpoint/v2.0"
+        - name: Authorization
+          in: header
+          required: false
+          description: Beckn Signature authentication header (Body Mode only).
+          schema:
+            $ref: "#/components/schemas/Signature"
+        - $ref: "#/components/parameters/AuthorizationQuery"
+        - $ref: "#/components/parameters/RequestActionQuery"
+      requestBody:
+        required: false
+        description: Body Mode only — MUST be absent when query parameters are used.
+        content:
+          application/json:
+            schema:
+              $ref: "https://schema.beckn.io/BecknAction/v2.0"
+      responses:
+        "200":
+          $ref: "#/components/responses/Ack"
+        "400":
+          $ref: "#/components/responses/NackBadRequest"
+        "401":
+          $ref: "#/components/responses/NackUnauthorized"
+        "409":
+          $ref: "#/components/responses/AckNoCallback"
+        "500":
+          $ref: "#/components/responses/ServerError"
+    post:
+      summary: Dispatch a Beckn protocol action on an HTTP POST endpoint
+      description: |
+        Universal endpoint for dispatching any Beckn protocol action across a Beckn-enabled network.
+
+        The request body MUST conform to `BecknAction` — the unified schema for all Beckn requests and callbacks. The `action` value in the path (and in `context.action`) determines which message content schema applies.
+
+        All requests MUST be authenticated using a valid Beckn Signature in the `Authorization` header.
+      parameters:
+        - $ref: "#/components/parameters/AuthorizationHeader"
+        - name: becknEndpoint
+          in: path
+          required: true
+          schema:
+            $ref: "https://schema.beckn.io/BecknEndpoint/v2.0"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "https://schema.beckn.io/BecknAction/v2.0"
+      responses:
+        "200":
+          $ref: "#/components/responses/Ack"
+        "400":
+          $ref: "#/components/responses/NackBadRequest"
+        "401":
+          $ref: "#/components/responses/NackUnauthorized"
+        "409":
+          $ref: "#/components/responses/AckNoCallback"
+        "500":
+          $ref: "#/components/responses/ServerError"
+
+components:
+  schemas:
+    $ref: "../schema/core.yaml#/components/schemas"
+
+  parameters:
+    $ref: "../schema/core.yaml#/components/parameters"
+
+  responses:
+    $ref: "../schema/core.yaml#/components/responses"

--- a/api/v2.0.0/components/schema/core.yaml
+++ b/api/v2.0.0/components/schema/core.yaml
@@ -1,0 +1,267 @@
+openapi: 3.1.1
+info:
+  title: Beckn Protocol — Transport Layer Schemas
+  description: |
+    Transport-layer schemas, parameters, and responses for Beckn Protocol v2.0.
+
+    These schemas describe the protocol mechanics — authentication, acknowledgement,
+    error handling, cryptographic binding, and counter-signature — that apply to
+    every Beckn endpoint regardless of action. They are the building blocks used
+    by the generated `api/v2.0.0/beckn.yaml`.
+
+    Data model schemas (Context, BecknAction, Intent, Catalog, Contract, etc.)
+    live in https://github.com/beckn/core_schema and are resolved from
+    https://schema.beckn.io during endpoint generation.
+  version: 2.0.0
+
+components:
+  schemas:
+
+    Ack:
+      title: Acknowledgement
+      description: Synchronous receipt acknowledgement returned for every accepted Beckn request.
+      type: object
+      properties:
+        status:
+          type: string
+          description: ACK if the request was accepted; NACK if rejected.
+          enum:
+            - ACK
+            - NACK
+        signature:
+          allOf:
+            - $ref: "#/components/schemas/CounterSignature"
+          description: Counter-signature proving the receiver authenticated and processed the inbound request.
+      required:
+        - status
+        - signature
+
+    AckNoCallback:
+      title: Acknowledgement — No Callback
+      description: |
+        Request received and valid, but no asynchronous callback will follow. Typical causes:
+        no matching agents found, inventory unavailable, store closed.
+      allOf:
+        - $ref: "#/components/schemas/Ack"
+        - properties:
+            error:
+              allOf:
+                - $ref: "#/components/schemas/Error"
+              description: Optional error detail explaining why no callback will follow.
+
+    AsyncError:
+      title: Asynchronous Error
+      description: |
+        Error returned asynchronously during a callback. Wraps the base `Error` schema with
+        JSON-LD type annotations.
+      allOf:
+        - $ref: "#/components/schemas/Error"
+        - properties:
+            "@context":
+              type: string
+              default: "https://schema.beckn.io/"
+            "@type":
+              type: string
+              default: "AsyncError"
+          additionalProperties: true
+
+    CounterSignature:
+      title: Beckn HTTP Counter-Signature
+      description: |
+        A signed receipt transmitted in the synchronous `Ack` response body, proving that the
+        receiver authenticated, received, and processed the inbound request. It is the schema
+        realisation of the Signed Receipt of Receipt concept proposed in
+        [Issue #69](https://github.com/beckn/protocol-specifications-v2/issues/69).
+
+        `CounterSignature` shares the same wire format as `Signature` but differs in three ways:
+
+        | Aspect | `Signature` | `CounterSignature` |
+        |---|---|---|
+        | **Signer** | Request sender (BAP/BPP) | Response receiver (BPP/BAP) |
+        | **Transmitted in** | Inbound `Authorization` header | `Ack.signature` in response body |
+        | **`digest`** | BLAKE2b-512 of **inbound request** body | BLAKE2b-512 of **Ack response** body |
+        | **`(request-digest)`** | Not present | MUST be present |
+        | **`(message-id)`** | Not present | MUST be present |
+        | **`headers`** | `"(created) (expires) digest"` | `"(created) (expires) digest (request-digest) (message-id)"` |
+
+        **Signing string:**
+        ```
+        (created): {unixTimestamp}
+        (expires): {unixTimestamp}
+        digest: BLAKE-512={base64DigestOfAckBody}
+        (request-digest): BLAKE-512={base64DigestOfInboundRequestBody}
+        (message-id): {messageId}
+        ```
+      allOf:
+        - $ref: "#/components/schemas/Signature"
+      example: 'Signature keyId="example-bpp.com|74b43deb-236e-4498-8f5a-ca75d6c67b9d|ed25519",algorithm="ed25519",created="1641287900",expires="1641291500",headers="(created) (expires) digest (request-digest) (message-id)",signature="mX3sHA+9gileOkXYJXh4Jg8tK0gEEMbf9yCPnFpbldhrAY+NErqL9WD+Vav7TE5tyVXGXBle9ONZi2W7o144eQ=="'
+
+    Error:
+      title: Error
+      description: Base error container returned in NACK responses and async error callbacks.
+      type: object
+      properties:
+        errorCode:
+          type: string
+          description: Machine-readable error code.
+        errorMessage:
+          type: string
+          description: Human-readable error description.
+
+    InReplyTo:
+      title: In-Reply-To Reference
+      description: |
+        A cryptographic binding that ties an asynchronous `on_<action>` callback to the specific
+        inbound request that triggered it. Implements
+        [Issue #69 Proposal #1 — Cryptographic Request–Response Binding](https://github.com/beckn/protocol-specifications-v2/issues/69).
+
+        Including `inReplyTo` in a callback establishes **bilateral non-repudiation for the
+        asynchronous leg** of a Beckn interaction. It is strictly conversational — it links a
+        callback to its parent within the same transaction. Use `context.lineage` for
+        cross-transaction causality.
+
+        **Verification steps:**
+        1. Recompute the BLAKE2b-512 digest of the original request body and compare to `digest`.
+        2. Confirm `messageId` matches the `messageId` from the original request `Context`.
+      type: object
+      properties:
+        messageId:
+          description: The `messageId` of the parent request from its `Context`.
+          type: string
+          format: uuid
+        digest:
+          description: |
+            BLAKE2b-512 hash of the parent request body, Base64-encoded with algorithm prefix.
+            Format: `BLAKE-512={base64EncodedHash}`
+          type: string
+          pattern: "^BLAKE-512=[A-Za-z0-9+/]+=*$"
+      required:
+        - messageId
+        - digest
+
+    NackBadRequest:
+      title: NACK — Bad Request
+      description: Malformed or invalid request; the server could not parse or validate the payload.
+      allOf:
+        - $ref: "#/components/schemas/Ack"
+        - properties:
+            status:
+              type: string
+              const: NACK
+            error:
+              allOf:
+                - $ref: "#/components/schemas/Error"
+
+    NackUnauthorized:
+      title: NACK — Unauthorized
+      description: Invalid or missing authentication credentials; signature could not be verified.
+      allOf:
+        - $ref: "#/components/schemas/Ack"
+        - properties:
+            status:
+              type: string
+              const: NACK
+            error:
+              allOf:
+                - $ref: "#/components/schemas/Error"
+
+    ServerError:
+      title: Server Error
+      description: Internal failure on the network participant's platform; the request could not be processed.
+      type: object
+
+    Signature:
+      title: Beckn HTTP Signature
+      description: |
+        A digitally signed authentication credential in the HTTP `Authorization` header.
+        Follows the HTTP Signature scheme from
+        [draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12)
+        as profiled by [BECKN-006](https://github.com/beckn/protocol-specifications/blob/master/docs/BECKN-006-Signing-Beckn-APIs-In-HTTP-Draft-01.md).
+
+        **Format:**
+        ```
+        Signature keyId="{subscriberId}|{uniqueKeyId}|{algorithm}",algorithm="{algorithm}",created="{unixTimestamp}",expires="{unixTimestamp}",headers="{signedHeaders}",signature="{base64Signature}"
+        ```
+
+        | Attribute | Description |
+        |---|---|
+        | `keyId` | `{subscriberId}\|{uniqueKeyId}\|{algorithm}` — FQDN, registry UUID, signing algorithm |
+        | `algorithm` | MUST be `ed25519` |
+        | `created` | Unix timestamp when the signature was created |
+        | `expires` | Unix timestamp when the signature expires |
+        | `headers` | Space-separated signed headers. MUST include `(created)`, `(expires)`, `digest` |
+        | `signature` | Base64-encoded Ed25519 signature over the signing string |
+
+        The signing string is formed by concatenating:
+        `(created): {value}\n(expires): {value}\ndigest: BLAKE-512={digest}`,
+        where `digest` is a BLAKE2b-512 hash of the request body, Base64-encoded.
+      type: string
+      pattern: '^Signature keyId="[^|"]+\|[^|"]+\|[^"]+",algorithm="[^"]+",created="\d+",expires="\d+",headers="[^"]+",signature="[A-Za-z0-9+/]+=*"$'
+      example: 'Signature keyId="example-bap.com|ae3ea24b-cfec-495e-81f8-044aaef164ac|ed25519",algorithm="ed25519",created="1641287875",expires="1641291475",headers="(created) (expires) digest",signature="cjbhP0PFyrlSCNszJM1F/YmHDVAWsZqJUPzojnE/7TJU3fJ/rmIlgaUHEr5E0/2PIyf0tpSnWtT6cyNNlpmoAQ=="'
+
+  parameters:
+
+    AuthorizationHeader:
+      name: Authorization
+      in: header
+      required: true
+      description: |
+        Beckn Signature authentication header (POST endpoints and GET Body Mode).
+        See `#/components/schemas/Signature` for the expected format.
+      schema:
+        $ref: "#/components/schemas/Signature"
+
+    AuthorizationQuery:
+      name: Authorization
+      in: query
+      required: false
+      description: |
+        Beckn Signature passed as a query parameter (GET Query Mode only).
+        Mutually exclusive with the `Authorization` header and the request body.
+      schema:
+        $ref: "#/components/schemas/Signature"
+
+    RequestActionQuery:
+      name: RequestAction
+      in: query
+      required: false
+      description: |
+        Beckn action payload passed as a URL-encoded query parameter (GET Query Mode only).
+        The value is a JSON-serialised `BecknAction`. Mutually exclusive with the request body.
+
+  responses:
+
+    Ack:
+      description: Receipt confirmed; signature valid; asynchronous callback will follow.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Ack"
+
+    AckNoCallback:
+      description: Request received but no callback will follow (e.g. agents not found, inventory unavailable).
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AckNoCallback"
+
+    NackBadRequest:
+      description: Malformed or invalid request; the server could not parse or validate the payload.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/NackBadRequest"
+
+    NackUnauthorized:
+      description: Invalid or missing authentication credentials; signature could not be verified.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/NackUnauthorized"
+
+    ServerError:
+      description: Internal failure on the network participant's platform.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ServerError"

--- a/scripts/generate_endpoints.py
+++ b/scripts/generate_endpoints.py
@@ -1,0 +1,663 @@
+#!/usr/bin/env python3
+"""
+generate_endpoints.py
+─────────────────────
+Generates api/v2.0.0/beckn.yaml — a fully resolved, concrete OpenAPI
+specification with one named path per known Beckn endpoint.
+
+Inputs (all relative to the protocol-specifications-v2 root):
+  api/v2.0.0/components/io/core.yaml      abstract IO spec (source of truth)
+  api/v2.0.0/components/schema/core.yaml  transport-layer schemas
+  ../core_schema/schema/**                data model schemas
+
+Output:
+  api/v2.0.0/beckn.yaml                   fully resolved, 20 concrete paths
+
+Usage:
+  cd protocol-specifications-v2
+  python3 scripts/generate_endpoints.py [options]
+
+  --core-schema PATH   path to core_schema/schema/ (default: ../core_schema/schema)
+  --output PATH        output path (default: api/v2.0.0/beckn.yaml)
+  --dry-run            preview without writing
+"""
+
+from __future__ import annotations
+import argparse
+import copy
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: pyyaml is required. Install: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+BECKN_IO = "https://schema.beckn.io/"
+
+# Human-readable metadata for each known Beckn endpoint.
+ENDPOINT_META: dict[str, dict] = {
+    "beckn/discover": {
+        "summary": "Discover — BAP sends a discovery request",
+        "description": (
+            "BAP sends a discovery intent to one or more BPPs to find catalogs "
+            "matching the consumer's requirements. The intent may carry a free-text "
+            "query, structured filters, spatial constraints, or media inputs."
+        ),
+        "direction": "BAP → BPP",
+    },
+    "beckn/on_discover": {
+        "summary": "On-Discover — BPP returns matching catalogs",
+        "description": (
+            "BPP responds to a discover request with catalogs that match the "
+            "expressed intent. Each catalog contains the provider's items, offers, "
+            "fulfillment options, and pricing."
+        ),
+        "direction": "BPP → BAP (async callback)",
+    },
+    "beckn/select": {
+        "summary": "Select — BAP selects items and requests a quote",
+        "description": (
+            "BAP sends the consumer's selected items and asks the BPP to generate "
+            "a draft contract with pricing, taxes, and available fulfillment options."
+        ),
+        "direction": "BAP → BPP",
+    },
+    "beckn/on_select": {
+        "summary": "On-Select — BPP returns a draft contract with quote",
+        "description": (
+            "BPP responds with a draft contract reflecting the selected items, "
+            "computed pricing, applicable taxes, and fulfillment options."
+        ),
+        "direction": "BPP → BAP (async callback)",
+    },
+    "beckn/init": {
+        "summary": "Init — BAP submits billing and fulfillment details",
+        "description": (
+            "BAP submits the consumer's billing address, chosen fulfillment option, "
+            "and preferred payment method to initiate an order."
+        ),
+        "direction": "BAP → BPP",
+    },
+    "beckn/on_init": {
+        "summary": "On-Init — BPP returns final terms and payment instructions",
+        "description": (
+            "BPP responds with the final order terms, complete price breakdown, "
+            "and payment/settlement instructions. The consumer reviews these terms "
+            "before confirming."
+        ),
+        "direction": "BPP → BAP (async callback)",
+    },
+    "beckn/confirm": {
+        "summary": "Confirm — BAP confirms the order",
+        "description": (
+            "BAP confirms the order after the consumer has reviewed and accepted the "
+            "final terms returned in on_init. This creates a binding order."
+        ),
+        "direction": "BAP → BPP",
+    },
+    "beckn/on_confirm": {
+        "summary": "On-Confirm — BPP acknowledges order confirmation",
+        "description": (
+            "BPP acknowledges the confirmed order and returns the active contract "
+            "with the assigned order identifier and fulfillment state."
+        ),
+        "direction": "BPP → BAP (async callback)",
+    },
+    "beckn/status": {
+        "summary": "Status — BAP queries current order status",
+        "description": (
+            "BAP requests the current status of a previously confirmed order by "
+            "providing the order identifier."
+        ),
+        "direction": "BAP → BPP",
+    },
+    "beckn/on_status": {
+        "summary": "On-Status — BPP returns current order status",
+        "description": (
+            "BPP returns the current state of the order, including the latest "
+            "fulfillment stage, tracking state, and any active alerts."
+        ),
+        "direction": "BPP → BAP (async callback)",
+    },
+    "beckn/track": {
+        "summary": "Track — BAP requests a real-time tracking link",
+        "description": (
+            "BAP requests a real-time tracking URL or WebSocket handle for an "
+            "active fulfillment leg."
+        ),
+        "direction": "BAP → BPP",
+    },
+    "beckn/on_track": {
+        "summary": "On-Track — BPP returns tracking information",
+        "description": (
+            "BPP returns a tracking URL, WebSocket handle, or embedded real-time "
+            "tracking feed for the active fulfillment."
+        ),
+        "direction": "BPP → BAP (async callback)",
+    },
+    "beckn/update": {
+        "summary": "Update — BAP updates an active order",
+        "description": (
+            "BAP requests a modification to an active order, such as changing the "
+            "fulfillment address, adjusting quantities, or adding items."
+        ),
+        "direction": "BAP → BPP",
+    },
+    "beckn/on_update": {
+        "summary": "On-Update — BPP returns the updated contract",
+        "description": (
+            "BPP returns the updated contract reflecting the applied changes, "
+            "including any pricing adjustments."
+        ),
+        "direction": "BPP → BAP (async callback)",
+    },
+    "beckn/cancel": {
+        "summary": "Cancel — BAP cancels an active order",
+        "description": (
+            "BAP cancels an active order, providing a cancellation reason code "
+            "as defined in the applicable cancellation policy."
+        ),
+        "direction": "BAP → BPP",
+    },
+    "beckn/on_cancel": {
+        "summary": "On-Cancel — BPP confirms order cancellation",
+        "description": (
+            "BPP confirms the cancellation and returns the final contract state, "
+            "including any applicable refund terms."
+        ),
+        "direction": "BPP → BAP (async callback)",
+    },
+    "beckn/rate": {
+        "summary": "Rate — BAP submits ratings and feedback",
+        "description": (
+            "BAP submits one or more ratings for entities in the completed order "
+            "(item, fulfillment, provider, or agent), optionally with feedback "
+            "form submissions."
+        ),
+        "direction": "BAP → BPP",
+    },
+    "beckn/on_rate": {
+        "summary": "On-Rate — BPP returns rating forms",
+        "description": (
+            "BPP returns rating forms for the BAP to present to the consumer, "
+            "enabling collection of structured feedback."
+        ),
+        "direction": "BPP → BAP (async callback)",
+    },
+    "beckn/support": {
+        "summary": "Support — BAP requests support contact information",
+        "description": (
+            "BAP requests support contact details for a specific order or entity. "
+            "The consumer may also initiate a support callback request."
+        ),
+        "direction": "BAP → BPP",
+    },
+    "beckn/on_support": {
+        "summary": "On-Support — BPP returns support contact details",
+        "description": (
+            "BPP returns support contact information including email address, "
+            "telephone number, chat endpoint, and available support channels."
+        ),
+        "direction": "BPP → BAP (async callback)",
+    },
+}
+
+
+# ─── Schema naming helpers ────────────────────────────────────────────────────
+
+def action_to_schema_name(action: str) -> str:
+    """
+    Convert a beckn action value to a CamelCase request schema name.
+
+    beckn/discover       → DiscoverRequest
+    beckn/on_discover    → OnDiscoverRequest
+    beckn/support        → SupportActionRequest  (avoids clash with SupportRequest data model)
+    """
+    # Strip 'beckn/' prefix; handle sub-namespaces like 'beckn/igm/raise_grievance'
+    parts = action.split("/")[1:]  # drop 'beckn'
+    joined = "_".join(parts)
+    name = "".join(word.capitalize() for word in joined.split("_")) + "Request"
+
+    # Avoid collision with the SupportRequest data model schema
+    if action == "beckn/support":
+        name = "SupportActionRequest"
+
+    return name
+
+
+def uri_to_schema_name(uri: str) -> str:
+    """
+    Extract the schema name from a schema.beckn.io URI.
+    https://schema.beckn.io/Intent/v2.0 → Intent
+    """
+    parts = uri.rstrip("/").split("/")
+    # URI pattern: https://schema.beckn.io/{Name}/{version}
+    # Last two segments are Name and version; we want Name
+    if len(parts) >= 2:
+        return parts[-2]
+    return parts[-1]
+
+
+# ─── Schema loading ───────────────────────────────────────────────────────────
+
+def load_yaml(path: str) -> dict:
+    """Load a YAML file and return the parsed dict."""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def build_registry(schema_dir: str) -> dict[str, dict]:
+    """
+    Walk core_schema/schema/ and build a mapping:
+      https://schema.beckn.io/{Name}/{version}  →  parsed attributes.yaml dict
+    """
+    registry: dict[str, dict] = {}
+    root = Path(schema_dir)
+    for attrs in root.glob("*/*/attributes.yaml"):
+        try:
+            doc = load_yaml(str(attrs))
+            schema_id = doc.get("$id")
+            if schema_id:
+                # Normalise: strip trailing slash
+                registry[schema_id.rstrip("/")] = doc
+        except Exception as exc:
+            print(f"  WARNING: could not load {attrs}: {exc}", file=sys.stderr)
+    return registry
+
+
+# ─── $ref collection & rewriting ─────────────────────────────────────────────
+
+def collect_refs(obj, found: set[str]) -> None:
+    """Recursively collect all beckn.io $ref base URIs (no fragment)."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k == "$ref" and isinstance(v, str) and v.startswith(BECKN_IO):
+                found.add(v.split("#")[0].rstrip("/"))
+            else:
+                collect_refs(v, found)
+    elif isinstance(obj, list):
+        for item in obj:
+            collect_refs(item, found)
+
+
+def resolve_transitively(seeds: list[str], registry: dict[str, dict]) -> dict[str, dict]:
+    """
+    Starting from seed URIs, transitively load all referenced schemas.
+    Returns {schema_name: cleaned_schema_dict} where the schema is stripped
+    of $id/$schema (kept inside title/description for traceability).
+    """
+    resolved: dict[str, dict] = {}
+    queue = list(seeds)
+    visited: set[str] = set()
+
+    while queue:
+        uri = queue.pop(0)
+        if uri in visited:
+            continue
+        visited.add(uri)
+
+        doc = registry.get(uri)
+        if not doc:
+            print(f"  WARNING: $ref not in registry: {uri}", file=sys.stderr)
+            continue
+
+        name = uri_to_schema_name(uri)
+        if name in resolved:
+            continue
+
+        # Store cleaned schema (keep $id as x-source-id for traceability; remove $schema)
+        cleaned = {k: v for k, v in doc.items() if k != "$schema"}
+        # Move $id to an extension field so it doesn't confuse OpenAPI tooling
+        if "$id" in cleaned:
+            cleaned["x-source-id"] = cleaned.pop("$id")
+        resolved[name] = cleaned
+
+        # Queue any new $refs found in this schema
+        new_refs: set[str] = set()
+        collect_refs(cleaned, new_refs)
+        for ref in new_refs:
+            if ref not in visited:
+                queue.append(ref)
+
+    return resolved
+
+
+def rewrite_refs(obj, name_map: dict[str, str]):
+    """
+    Rewrite https://schema.beckn.io/X/v2.0[#fragment] → #/components/schemas/X[fragment].
+    name_map maps URI → component schema name.
+    """
+    if isinstance(obj, dict):
+        result: dict = {}
+        for k, v in obj.items():
+            if k == "$ref" and isinstance(v, str) and v.startswith(BECKN_IO):
+                base = v.split("#")[0].rstrip("/")
+                fragment = v[len(base):]
+                comp_name = name_map.get(base)
+                result[k] = f"#/components/schemas/{comp_name}{fragment}" if comp_name else v
+            else:
+                result[k] = rewrite_refs(v, name_map)
+        return result
+    if isinstance(obj, list):
+        return [rewrite_refs(item, name_map) for item in obj]
+    return obj
+
+
+# ─── BecknAction parsing ──────────────────────────────────────────────────────
+
+def parse_endpoints(beckn_action: dict) -> list[dict]:
+    """
+    Extract each if/then branch from BecknAction.allOf.
+    Returns a list of:
+      { action: str, message_props: dict, message_required: list[str] }
+    """
+    results = []
+    for block in beckn_action.get("allOf", []):
+        try:
+            action = block["if"]["properties"]["context"]["properties"]["action"]["const"]
+        except (KeyError, TypeError):
+            continue
+        then_msg = block.get("then", {}).get("properties", {}).get("message", {})
+        results.append(
+            {
+                "action": action,
+                "message_props": copy.deepcopy(then_msg.get("properties", {})),
+                "message_required": then_msg.get("required", []),
+            }
+        )
+    return results
+
+
+# ─── Schema builders ──────────────────────────────────────────────────────────
+
+def build_request_schema(action: str, message_props: dict, message_required: list) -> dict:
+    """
+    Build a concrete OpenAPI schema for one endpoint's request envelope.
+    context.action is constrained to this specific action value.
+    """
+    name = action_to_schema_name(action)
+    msg_schema: dict = {
+        "description": f"Action-specific payload for `{action}`.",
+        "type": "object",
+    }
+    if message_required:
+        msg_schema["required"] = message_required
+    if message_props:
+        msg_schema["properties"] = message_props
+
+    return {
+        "title": name,
+        "description": (
+            f"Beckn Protocol request envelope for the `{action}` endpoint.\n\n"
+            f"`context.action` MUST be set to `{action}`."
+        ),
+        "type": "object",
+        "required": ["context", "message"],
+        "additionalProperties": False,
+        "properties": {
+            "context": {
+                "description": (
+                    f"Transaction context. "
+                    f"`context.action` MUST be `{action}`."
+                ),
+                "allOf": [{"$ref": "#/components/schemas/Context"}],
+            },
+            "message": msg_schema,
+        },
+    }
+
+
+def build_path(action: str) -> dict:
+    """Build the OpenAPI path entry for a concrete Beckn endpoint."""
+    schema_name = action_to_schema_name(action)
+    meta = ENDPOINT_META.get(action, {})
+    summary = meta.get("summary", action)
+    description = meta.get("description", "")
+    direction = meta.get("direction", "")
+    if direction:
+        description += f"\n\n**Direction:** {direction}"
+
+    return {
+        "post": {
+            "summary": summary,
+            "description": description,
+            "operationId": action.replace("/", "_"),
+            "tags": [action.split("/")[1].replace("on_", "").capitalize()],
+            "parameters": [{"$ref": "#/components/parameters/AuthorizationHeader"}],
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": f"#/components/schemas/{schema_name}"}
+                    }
+                },
+            },
+            "responses": {
+                "200": {"$ref": "#/components/responses/Ack"},
+                "400": {"$ref": "#/components/responses/NackBadRequest"},
+                "401": {"$ref": "#/components/responses/NackUnauthorized"},
+                "409": {"$ref": "#/components/responses/AckNoCallback"},
+                "500": {"$ref": "#/components/responses/ServerError"},
+            },
+        }
+    }
+
+
+# ─── YAML dump with no aliases ────────────────────────────────────────────────
+
+class NoAliasDumper(yaml.Dumper):
+    """YAML Dumper that never emits aliases — all repeated nodes are written in full."""
+    def ignore_aliases(self, data):
+        return True
+
+
+# ─── Main generator ───────────────────────────────────────────────────────────
+
+def generate(
+    core_schema_dir: str,
+    transport_path: str,
+    output_path: str,
+    dry_run: bool = False,
+) -> None:
+
+    print(f"[1/6] Building schema registry from {core_schema_dir} ...")
+    registry = build_registry(core_schema_dir)
+    print(f"      {len(registry)} schemas loaded")
+
+    print("[2/6] Loading transport schemas ...")
+    transport = load_yaml(transport_path)
+    transport_components = transport.get("components", {})
+
+    print("[3/6] Parsing BecknAction endpoints ...")
+    beckn_action_uri = "https://schema.beckn.io/BecknAction/v2.0"
+    beckn_action = registry.get(beckn_action_uri)
+    if beckn_action is None:
+        print(f"ERROR: BecknAction not found in registry: {beckn_action_uri}", file=sys.stderr)
+        sys.exit(1)
+
+    raw_endpoints = parse_endpoints(beckn_action)
+    if not raw_endpoints:
+        print("ERROR: No if/then endpoints found in BecknAction.allOf", file=sys.stderr)
+        sys.exit(1)
+    print(f"      {len(raw_endpoints)} endpoints found")
+
+    print("[4/6] Resolving data model schemas transitively ...")
+    # Seed with Context, BecknEndpoint, LineageEntry, Message (always required)
+    seeds: set[str] = {
+        "https://schema.beckn.io/Context/v2.0",
+        "https://schema.beckn.io/BecknEndpoint/v2.0",
+        "https://schema.beckn.io/LineageEntry/v2.0",
+        "https://schema.beckn.io/Message/v2.0",
+    }
+    # Add all refs from each endpoint's message properties
+    endpoint_schemas: dict[str, dict] = {}
+    paths: dict[str, dict] = {}
+
+    for ep in raw_endpoints:
+        action = ep["action"]
+        collect_refs(ep["message_props"], seeds)
+        endpoint_schemas[action_to_schema_name(action)] = build_request_schema(
+            action, ep["message_props"], ep["message_required"]
+        )
+        paths[f"/{action}"] = build_path(action)
+
+    # Resolve all seeds transitively
+    data_model_schemas = resolve_transitively(list(seeds), registry)
+    print(f"      {len(data_model_schemas)} data model schemas resolved")
+
+    # Build URI → name map for ref rewriting
+    ref_map: dict[str, str] = {}
+    for uri in registry:
+        ref_map[uri.rstrip("/")] = uri_to_schema_name(uri)
+
+    print("[5/6] Rewriting $refs to #/components/schemas/ ...")
+    data_model_schemas = {n: rewrite_refs(s, ref_map) for n, s in data_model_schemas.items()}
+    endpoint_schemas = {n: rewrite_refs(s, ref_map) for n, s in endpoint_schemas.items()}
+
+    print("[6/6] Assembling beckn.yaml ...")
+
+    # Merge all schemas:
+    #   1. Transport (Signature, Ack, Error, ...) from components/schema/core.yaml
+    #   2. Data model schemas (from core_schema, refs rewritten)
+    #   3. Endpoint request schemas (concrete per-action envelopes)
+    all_schemas: dict = {}
+    all_schemas.update(transport_components.get("schemas", {}))
+    all_schemas.update(data_model_schemas)
+    all_schemas.update(endpoint_schemas)
+
+    output_doc = {
+        "openapi": "3.1.1",
+        "info": {
+            "title": "Beckn Protocol API Specification Version 2",
+            "description": textwrap.dedent("""\
+                The API specification of Beckn Protocol — a fully resolved, concrete OpenAPI
+                specification with one named path per known Beckn endpoint.
+
+                **Interaction model:** All Beckn interactions are asynchronous. The caller sends
+                a request and receives a synchronous `Ack` (HTTP 200). The actual response
+                arrives as a separate callback on the caller's registered callback endpoint
+                using the corresponding `on_<action>` endpoint.
+
+                **Authentication:** All requests MUST carry a Beckn Signature in the
+                `Authorization` header. See the `Signature` schema for the expected format.
+
+                ---
+
+                ⚠️ **THIS FILE IS AUTO-GENERATED. Do not edit directly.**
+
+                | Source | Path |
+                |--------|------|
+                | Abstract IO spec | `api/v2.0.0/components/io/core.yaml` |
+                | Transport schemas | `api/v2.0.0/components/schema/core.yaml` |
+                | Data model schemas | `https://github.com/beckn/core_schema` |
+                | Generator | `scripts/generate_endpoints.py` |
+
+                Regenerate: `cd protocol-specifications-v2 && python3 scripts/generate_endpoints.py`
+                """),
+            "version": "2.0.0",
+            "contact": {"name": "Beckn Protocol", "url": "https://beckn.io"},
+            "license": {
+                "name": "CC-BY-NC-SA 4.0 International",
+                "url": "https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en",
+            },
+        },
+        "paths": paths,
+        "components": {
+            "schemas": all_schemas,
+            "parameters": transport_components.get("parameters", {}),
+            "responses": transport_components.get("responses", {}),
+        },
+    }
+
+    if dry_run:
+        print(f"\n[DRY RUN] Would write to: {output_path}")
+        print(f"  Paths:   {len(paths)}")
+        print(f"  Schemas: {len(all_schemas)}")
+        return
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(
+            "# AUTO-GENERATED — DO NOT EDIT DIRECTLY\n"
+            "# Sources: api/v2.0.0/components/io/core.yaml  |  "
+            "api/v2.0.0/components/schema/core.yaml  |  "
+            "github.com/beckn/core_schema\n"
+            "# Regenerate: cd protocol-specifications-v2 && "
+            "python3 scripts/generate_endpoints.py\n"
+            "#\n"
+        )
+        yaml.dump(
+            output_doc,
+            f,
+            Dumper=NoAliasDumper,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+            width=120,
+        )
+
+    print(f"\n✓ Written to: {output_path}")
+    print(f"  Paths:   {len(paths)}")
+    print(f"  Schemas: {len(all_schemas)}")
+
+
+# ─── CLI entry point ──────────────────────────────────────────────────────────
+
+def main() -> None:
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parent  # protocol-specifications-v2/
+
+    parser = argparse.ArgumentParser(
+        description="Generate resolved Beckn Protocol endpoint YAML",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--core-schema",
+        default=str(repo_root.parent / "core_schema" / "schema"),
+        metavar="PATH",
+        help="Path to core_schema/schema directory (default: ../core_schema/schema)",
+    )
+    parser.add_argument(
+        "--transport-schemas",
+        default=str(repo_root / "api" / "v2.0.0" / "components" / "schema" / "core.yaml"),
+        metavar="PATH",
+        help="Path to transport schemas YAML",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(repo_root / "api" / "v2.0.0" / "beckn.yaml"),
+        metavar="PATH",
+        help="Output path for generated beckn.yaml",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview what would be generated without writing any files",
+    )
+    args = parser.parse_args()
+
+    print("Beckn Endpoint Generator")
+    print("=" * 50)
+    print(f"Core schema dir:   {args.core_schema}")
+    print(f"Transport schemas: {args.transport_schemas}")
+    print(f"Output:            {args.output}")
+    print()
+
+    generate(
+        core_schema_dir=args.core_schema,
+        transport_path=args.transport_schemas,
+        output_path=args.output,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #95. Implements the architecture established in [RFC #93](https://github.com/beckn/protocol-specifications-v2/issues/93) and [Discussion #94](https://github.com/beckn/protocol-specifications-v2/discussions/94).

**Depends on:** `beckn/core_schema` PR #31 must merge first. `BecknAction`, `BecknEndpoint`, `Context`, `LineageEntry`, and `Message` must exist at `https://schema.beckn.io/` before this spec resolves correctly.

---

## What changed

### Endpoint references (2 touch points)

`beckn.yaml` now references `core_schema` at exactly two places:

```yaml
# Path parameter
schema:
  $ref: "https://schema.beckn.io/BecknEndpoint/v2.0"

# Request body (both GET and POST)
schema:
  $ref: "https://schema.beckn.io/BecknAction/v2.0"
```

### Request body simplification

**Before:** `POST` body used `oneOf: [RequestContainer, CallbackContainer]` — implying the protocol layer knows about the request/callback distinction.

**After:** Single `$ref: "https://schema.beckn.io/BecknAction/v2.0"`. `BecknAction` handles both directions. The request/callback distinction is encoded in `context.action` (e.g. `beckn/discover` vs `beckn/on_discover`), not in a separate schema type.

### Components delegated to core_schema

| Component | Before | After |
|---|---|---|
| `Context` | Large inline definition (diverged from core_schema version) | `$ref: "https://schema.beckn.io/Context/v2.0"` |
| `BecknEndpoint` | Inline string with regex pattern | `$ref: "https://schema.beckn.io/BecknEndpoint/v2.0"` |
| `Message` | Inline open object | `$ref: "https://schema.beckn.io/Message/v2.0"` |
| `LineageEntry` | Large inline definition | `$ref: "https://schema.beckn.io/LineageEntry/v2.0"` |
| `RequestContainer` | Inline `{context, message}` object | Deprecated alias → `BecknAction` |
| `CallbackContainer` | Inline `{context, inReplyTo, oneOf[message,error]}` | Deprecated alias → `BecknAction` |

### New component

`BecknAction: $ref: "https://schema.beckn.io/BecknAction/v2.0"` — alias for tooling that references the component by name.

### What stays inline (never changes with new actors)

`Signature`, `CounterSignature`, `InReplyTo`, `Ack`, `AckNoCallback`, `NackBadRequest`, `NackUnauthorized`, `ServerError`, `AsyncError`, `Error` — pure transport/crypto layer. These are the schemas that justify `protocol-specifications-v2` existing as a separate repo.

---

## Why this is the right design

Adding a new Beckn actor (IGM service, reconciliation service, AI agent, etc.) or a new endpoint now requires zero commits to `protocol-specifications-v2`. You add `BecknEndpoint` values and action schemas to `core_schema`. `beckn.yaml` is untouched.

This is the long-half-life design analogous to HTTP — the protocol transport is frozen; the schema registry evolves freely.