### PR TITLE
Remove enum values for Core Catalog and Item objects

### DIFF
--- a/schema/core/v2/attributes.yaml
+++ b/schema/core/v2/attributes.yaml
@@ -23,7 +23,6 @@ components:
           type: string
           format: uri
           description: JSON-LD context URI for the core Catalog schema
-          enum: ["https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"]
         "@type":
           type: string
           description: Type of the catalog
@@ -72,7 +71,6 @@ components:
           type: string
           format: uri
           description: JSON-LD context URI for the core Item schema
-          enum: ["https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld"]
         "@type":
           type: string
           description: Type of the core item


### PR DESCRIPTION
The `Catalog` and the `Item` core objects have an enum validation which can only accept the object definitions from the main branch. This validation is unnecessary and it is causing validations to fail when the API spec `beckn.yaml` is being used from other branches as well. This PR removes these enum values.