### PR TITLE
EV ChargingService schema change - qrIdentifier & vehicleType

### DIFF
--- a/schema/EvChargingService/v1/attributes.yaml
+++ b/schema/EvChargingService/v1/attributes.yaml
@@ -23,7 +23,7 @@ components:
     ########################################################################
     ChargingService:
       type: object
-      additionalProperties: false
+      additionalProperties: true
       required:
         - connectorType
         - maxPowerKW
@@ -37,6 +37,16 @@ components:
           description: EVSE identifier (e.g., OCPI/Hubject style).
           example: "IN*ECO*01*CCS2*A"
           x-jsonld: { "@id": evseId }
+
+        qrIdentifier:
+          type: string
+          description: >
+            The short URL or plain-text token encoded in the physical QR code
+            affixed to this connector. BPPs populate this during catalog publish
+            so that BAPs can discover a specific connector by scanning its QR
+            without requiring CPO-specific SDK logic to resolve the scanned value.
+          example: "https://charge.ecopower.in/cs01-ccs2"
+          x-jsonld: { "@id": qrIdentifier }
 
         # EV-specific technicals
         connectorType:
@@ -154,8 +164,21 @@ components:
           x-jsonld: { "@id": chargingSpeed }
 
         vehicleType:
-          type: string
-          enum: ["2-WHEELER", "3-WHEELER", "4-WHEELER"]
-          description: Type of vehicle that can use this charging service.
-          example: "4-WHEELER"
+          oneOf:
+            - type: string
+              enum: ["2-WHEELER", "3-WHEELER", "4-WHEELER"]
+              description: Single vehicle type supported by this charging service.
+              example: "4-WHEELER"
+            - type: array
+              items:
+                type: string
+                enum: ["2-WHEELER", "3-WHEELER", "4-WHEELER"]
+              minItems: 1
+              uniqueItems: true
+              description: Multiple vehicle types supported by this charging service.
+              example: ["2-WHEELER", "4-WHEELER"]
+          description: >
+            Vehicle type(s) that can use this charging service.
+            Use a single string for backwards compatibility or an array
+            when the connector supports multiple vehicle types.
           x-jsonld: { "@id": vehicleType }

--- a/schema/EvChargingService/v1/context.jsonld
+++ b/schema/EvChargingService/v1/context.jsonld
@@ -27,6 +27,7 @@
     "areaServed": "schema:areaServed",
     "category": "schema:category",
     "chargingStation": "beckn:chargingStation",
+    "qrIdentifier": "beckn:qrIdentifier",
     "amenityFeature": {
       "@id": "beckn:amenityFeature",
       "@type": "@id"

--- a/schema/EvChargingService/v1/vocab.jsonld
+++ b/schema/EvChargingService/v1/vocab.jsonld
@@ -69,6 +69,15 @@
       "schema:rangeIncludes": "schema:Text"
     },
     {
+      "@id": "beckn:qrIdentifier",
+      "@type": "rdf:Property",
+      "rdfs:label": "QR identifier",
+      "rdfs:comment": "The short URL or plain-text token encoded in the physical QR code affixed to this charging connector. BPPs populate this during catalog publish so that BAPs can discover a specific connector by scanning its QR, without requiring CPO-specific SDK logic to resolve the scanned value.",
+      "rdfs:domain": "beckn:ChargingService",
+      "schema:rangeIncludes": "schema:Text",
+      "rdfs:seeAlso": "https://schema.org/identifier"
+    },
+    {
       "@id": "beckn:roamingNetwork",
       "@type": "rdf:Property",
       "rdfs:label": "Roaming network",


### PR DESCRIPTION
**Overview**

Two schema changes have been made to EvChargingService/v1:
1. qrIdentifier — new property for standardised QR-based connector discovery
2. vehicleType — extended to support multiple vehicle types via oneOf

**1. qrIdentifier — QR-Based Connector Discovery**

Problem:
Each CPO encodes their connector QR codes differently. A generic BAP (e.g., a UBC mobile app) that scans a physical QR code on a charger had to embed CPO-specific SDK logic to translate the scanned string into a Beckn beckn:id. This does not scale as the number of CPOs grows.

Change:
A new optional property qrIdentifier has been added to the ChargingService attribute schema:

**yaml**
qrIdentifier:
  type: string
  description: >
    The short URL or plain-text token encoded in the physical QR code
    affixed to this connector. BPPs populate this during catalog publish
    so that BAPs can discover a specific connector by scanning its QR
    without requiring CPO-specific SDK logic.
  example: "https://charge.ecopower.in/cs01-ccs2"
  
 BPPs populate this field in catalog_publish. The BAP then uses it directly as a discover filter:
 
**json**
"filters": {
  "type": "jsonpath",
  "expression": "$[?(@.beckn:itemAttributes.qrIdentifier == 'https://charge.ecopower.in/cs01-ccs2')]"
}

**Note**: on additionalProperties: true: The ChargingService schema previously had additionalProperties: false. This has been relaxed to true to allow extension fields (like qrIdentifier) without requiring a core schema change every time a new field is introduced.

**2. vehicleType — Multi-Vehicle Support via oneOf** 

Problem
A single EVSE connector (e.g., a Type 2 AC socket) can physically serve multiple vehicle types — for example, both 2-wheelers and 4-wheelers. The previous schema only allowed a single string value, forcing BPPs to either pick one or duplicate the connector item. 

Change
vehicleType now uses OpenAPI's oneOf to accept either a single string or an array of strings, while remaining fully backwards compatible with existing payloads:

**yaml**
vehicleType:
  oneOf:
    - type: string
      enum: ["2-WHEELER", "3-WHEELER", "4-WHEELER"]
    - type: array
      items:
        type: string
        enum: ["2-WHEELER", "3-WHEELER", "4-WHEELER"]
      minItems: 1
      uniqueItems: true
