### PR TITLE
fix: Resolved a schema which was failing to support both version of it

### DIFF
--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -958,6 +958,37 @@ components:
             contract:
               $ref: '#/components/schemas/Contract'
 
+    # Bundle-safe legacy catalog (v2.0-style `beckn:` keys). Replaces remote
+    # `https://schema.beckn.io/Catalog/v2.0` in CatalogPublishAction so `$ref` resolution stays
+    # inside this OpenAPI document (remote copy inlined fragment refs to #/components/... that
+    # broke bundlers/validators when nested under CatalogPublishAction.oneOf[0]).
+    CatalogV20:
+      description: |
+        Legacy Beckn catalog document (v2.0 JSON-LD / `beckn:` surface). Semantically aligned with
+        schema.beckn.io/Catalog/v2.0; maintained here with only `#/components/schemas/*` links.
+      type: object
+      additionalProperties: true
+      properties:
+        '@context':
+          type: string
+          format: uri
+        '@type':
+          type: string
+        beckn:id:
+          type: string
+        beckn:providerId:
+          type: string
+        beckn:bppId:
+          type: string
+        beckn:bppUri:
+          type: string
+          format: uri
+        beckn:descriptor:
+          allOf:
+            - $ref: '#/components/schemas/Descriptor'
+        beckn:validity:
+          $ref: '#/components/schemas/TimePeriod'
+
     CatalogPublishAction:
       $id: https://schema.beckn.io/CatalogPublishAction/v2.0
       description: Catalog publish request payload.
@@ -969,7 +1000,7 @@ components:
             catalogs:
               type: array
               items:
-                $ref: https://schema.beckn.io/Catalog/v2.0
+                $ref: '#/components/schemas/CatalogV20'
         - type: object
           properties:
             catalogs:
@@ -1771,72 +1802,107 @@ components:
           additionalProperties: false
         - description: | 
             Every API call in beckn protocol has a context. It provides a high-level overview to the receiver about the nature of the intended transaction. Typically, it is the BAP that sets the transaction context based on the consumer''s location and action on their UI. But sometimes, during unsolicited callbacks, the BPP also sets the transaction context but it is usually the same as the context of a previous full-cycle, request-callback interaction between the BAP and the BPP. The context object contains four types of fields. <ol><li>Demographic information about the transaction using fields like `domain`, `country`, and `region`.</li><li>Addressing details like the sending and receiving platform''s ID and API URL.</li><li>Interoperability information like the protocol version that implemented by the sender and,</li><li>Transaction details like the method being called at the receiver''s endpoint, the transaction_id that represents an end-to-end user session at the BAP, a message ID to pair requests with callbacks, a timestamp to capture sending times, a ttl to specifiy the validity of the request, and a key to encrypt information if necessary.</li></ol> This object must be passed in every interaction between a BAP and a BPP. In HTTP/S implementations, it is not necessary to send the context during the synchronous response. However, in asynchronous protocols, the context must be sent during all interactions.
-          type: object
-          title: Context V1.0
-          properties:
-            domain:
-              description: Domain code that is relevant to this transaction context
-              type: string
-            location:
-              description: The location where the transaction is intended to be fulfilled.
-              type: object
+          allOf:
+            - type: object
+              title: Context V1.0
+              additionalProperties: true
               properties:
-                city:
-                  description: 'The city code where this transaction is restricted to'
+                domain:
+                  description: Domain code that is relevant to this transaction context
+                  type: string
+                location:
+                  description: The location where the transaction is intended to be fulfilled.
                   type: object
                   properties:
-                    code:
-                      type: string
-                country:
-                  description: 'The country code this transaction is restricted to'
-                  type: object
-                  properties:
-                    code:
-                      type: string
-            action:
-              description: The Beckn protocol method being called by the sender and executed at the receiver.
-              type: string
-            version:
-              type: string
-              description: Version of transaction protocol being used by the sender.
-            bap_id:
-              description: Subscriber ID of the BAP as registered on dedi.global
-              type: string
-            bap_uri:
-              description: | 
-                The callback URL of the BAP. 
+                    city:
+                      description: 'The city code where this transaction is restricted to'
+                      type: object
+                      properties:
+                        code:
+                          type: string
+                    country:
+                      description: 'The country code this transaction is restricted to'
+                      type: object
+                      properties:
+                        code:
+                          type: string
+                action:
+                  description: The Beckn protocol method being called by the sender and executed at the receiver.
+                  type: string
+                version:
+                  type: string
+                  description: Version of transaction protocol being used by the sender.
+                bap_id:
+                  description: Subscriber ID of the BAP as registered on dedi.global
+                  type: string
+                bap_uri:
+                  description: | 
+                    The callback URL of the BAP. 
 
-                REQUIRED: This should necessarily contain the same domain name as verified in its namespace under dedi.global, and MUST have the same URL as registered in its subscriber registry on dedi.global
-              type: string
-              format: uri
-            bpp_id:
-              description: Subscriber ID of the BPP as registered on dedi.global
-              type: string
-            bpp_uri:
-              description: | 
-                The request URL of the BPP. 
-                
-                REQUIRED: This MUST contain the same domain name as verified in its namespace under dedi.global, and MUST have the same URL as registered in its subscriber registry on dedi.global
-              type: string
-              format: uri
-            transaction_id:
-              description: 'This is a unique value which persists across all API calls from `search` through `confirm`. This is done to indicate an active user session across multiple requests. The BPPs can use this value to push personalized recommendations, and dynamic offerings related to an ongoing transaction despite being unaware of the user active on the BAP.'
-              type: string
-              format: uuid
-            message_id:
-              description: 'This is a unique value which persists during a request / callback cycle. Since beckn protocol APIs are asynchronous, BAPs need a common value to match an incoming callback from a BPP to an earlier call. This value can also be used to ignore duplicate messages coming from the BPP. It is recommended to generate a fresh message_id for every new interaction. When sending unsolicited callbacks, BPPs must generate a new message_id.'
-              type: string
-              format: uuid
-            timestamp:
-              description: Time of request generation in RFC3339 format
-              type: string
-              format: date-time
-            key:
-              description: The encryption public key of the sender
-              type: string
-            ttl:
-              description: The duration in ISO8601 format after timestamp for which this message holds valid
-              type: string
+                    REQUIRED: This should necessarily contain the same domain name as verified in its namespace under dedi.global, and MUST have the same URL as registered in its subscriber registry on dedi.global
+                  type: string
+                  format: uri
+                bpp_id:
+                  description: Subscriber ID of the BPP as registered on dedi.global
+                  type: string
+                bpp_uri:
+                  description: | 
+                    The request URL of the BPP. 
+                    
+                    REQUIRED: This MUST contain the same domain name as verified in its namespace under dedi.global, and MUST have the same URL as registered in its subscriber registry on dedi.global
+                  type: string
+                  format: uri
+                transaction_id:
+                  description: 'This is a unique value which persists across all API calls from `search` through `confirm`. This is done to indicate an active user session across multiple requests. The BPPs can use this value to push personalized recommendations, and dynamic offerings related to an ongoing transaction despite being unaware of the user active on the BAP.'
+                  type: string
+                  format: uuid
+                message_id:
+                  description: 'This is a unique value which persists during a request / callback cycle. Since beckn protocol APIs are asynchronous, BAPs need a common value to match an incoming callback from a BPP to an earlier call. This value can also be used to ignore duplicate messages coming from the BPP. It is recommended to generate a fresh message_id for every new interaction. When sending unsolicited callbacks, BPPs must generate a new message_id.'
+                  type: string
+                  format: uuid
+                timestamp:
+                  description: Time of request generation in RFC3339 format
+                  type: string
+                  format: date-time
+                key:
+                  description: The encryption public key of the sender
+                  type: string
+                ttl:
+                  description: The duration in ISO8601 format after timestamp for which this message holds valid
+                  type: string
+            - not:
+                description: |
+                  Fingerprint of Context v2.0 required-field set. V1 branch must reject instances
+                  that satisfy this pattern so `oneOf` is mutually exclusive with the v2 branch above.
+                type: object
+                required:
+                  - action
+                  - bapId
+                  - bapUri
+                  - messageId
+                  - timestamp
+                  - transactionId
+                  - version
+                properties:
+                  action:
+                    type: string
+                  bapId:
+                    type: string
+                  bapUri:
+                    type: string
+                    format: uri
+                  messageId:
+                    type: string
+                    format: uuid
+                  transactionId:
+                    type: string
+                    format: uuid
+                  timestamp:
+                    type: string
+                    format: date-time
+                  version:
+                    type: string
+                    const: "2.0.0"
 
     Contract:
       $id: https://schema.beckn.io/Contract/v2.1


### PR DESCRIPTION

This PR explains **two separate problems** we hit when loading `beckn.yaml` with a standard JSON Schema/OpenAPI toolchain (resolve `$ref` → single graph → compile with AJV). It contrasts **what the spec looked like before**, **why tooling failed or behaved oddly**, and **what we changed** on branch `catalog-schema-changes` (or equivalent).

---

## 1. `CatalogPublishAction`: legacy catalog branch + remote `$ref`

### What we need

`CatalogPublishAction` should support **two catalog shapes** in a `oneOf`:

- **Legacy** v2.0-style catalogs (e.g. `beckn:*` field names).
- **Current** v2.1 catalogs (`#/components/schemas/Catalog` in the same OpenAPI file).

### What was wrong (before)

The legacy branch pointed at the **remote** document:

```yaml
# Before (problematic)
CatalogPublishAction:
  oneOf:
    - properties:
        catalogs:
          type: array
          items:
            $ref: https://schema.beckn.io/Catalog/v2.0
    - properties:
        catalogs:
          type: array
          items:
            $ref: '#/components/schemas/Catalog'
```

When the bundler **downloads** `https://schema.beckn.io/Catalog/v2.0` and **merges** it into the same `components.schemas` graph as `beckn.yaml`, that inlined content often still contained **internal** links like:

```json
{
  "beckn:descriptor": {
    "$ref": "#/components/schemas/Descriptor"
  }
}
```

Those `#/components/schemas/...` paths are written as if the **root document** were the big OpenAPI file. After the remote catalog is **nested** inside `CatalogPublishAction → oneOf[0] → catalogs → items`, that pointer is **ambiguous or wrong**: it may resolve to unrelated paths (we saw errors involving `InitAction`, `Order`, etc.) or **fail to resolve** at compile time.

**In one sentence:** *Remote catalog content used fragment refs that assumed the OpenAPI file’s root, which breaks when that content is inlined as a nested schema.*

### What it should be (after)

Keep **both** branches in the spec, but make the legacy branch **bundle-safe**:

1. **Option A (what we did in the branch):** define a **local** component, e.g. `CatalogV20`, in `beckn.yaml` with the same **intent** as the remote catalog, but every `$ref` must be either:
   - `#/components/schemas/<Name>` **where `<Name>` exists in this `beckn.yaml`**, or  
   - a **full** `https://schema.beckn.io/...` URL to another published artifact that itself does not rely on wrong roots.

2. **Option B (alternative):** fix the **published** `https://schema.beckn.io/Catalog/v2.0` so it never uses `#/components/schemas/...` unless that path truly exists **in that document alone**; prefer full `https://schema.beckn.io/...` refs between artifacts.

**Example (after — local legacy component):**

```yaml
CatalogV20:
  type: object
  additionalProperties: true
  properties:
    beckn:id:
      type: string
    beckn:descriptor:
      allOf:
        - $ref: '#/components/schemas/Descriptor'
    beckn:validity:
      $ref: '#/components/schemas/TimePeriod'

CatalogPublishAction:
  oneOf:
    - type: object
      properties:
        catalogs:
          type: array
          items:
            $ref: '#/components/schemas/CatalogV20'
    - type: object
      properties:
        catalogs:
          type: array
          items:
            $ref: '#/components/schemas/Catalog'
```

*(Property names `Items` vs `items` must follow your real OpenAPI; the idea is: **local ref, local resolution.**)*

---

## 2. `Context`: `oneOf` [v2.0 | v1.0] overlap

### What we need

Both **Context v2.0** (camelCase, strict, `version: "2.0.0"`, `additionalProperties: false`) and **Context v1.0** (snake_case, looser) remain **documented** in one `oneOf` for backward compatibility.

### What was wrong (before)

JSON Schema **`oneOf`** means: **exactly one** subschema must validate the same JSON instance.

The **v1** branch was **very permissive** (many optional fields, default `additionalProperties` behaviour). A **valid v2** payload could **also** be accepted as an instance of the v1 branch (everything in v2 is either listed on v1 or allowed as extra). So **two** branches matched → **`oneOf` fails** for **correct v2** traffic.

**Tiny analogy:** two stencils: v2 is a tight cut-out; v1 is a large loose sheet. The v2 object fits the tight stencil **and** lies flat on the loose sheet → “exactly one stencil” is impossible.

### What it should be (after)

Branches must be **actually disjoint** for real traffic, without dropping v1:

**Pattern we used:** wrap the v1 branch in `allOf`:

1. The original v1 object (optional: `additionalProperties: true`).
2. **`not:`** a small “**v2 fingerprint**” schema: the **required** field set and `version: "2.0.0"` that characterises Context v2.0.

Any instance that **is** a valid v2 context **matches** the fingerprint → fails the `not` → **v1 branch rejects it**.  
A true v1-only instance **does not** match the fingerprint → passes `not` → v1 branch can succeed.

**Example (conceptual):**

```yaml
Context:
  oneOf:
    # Branch 0: v2.0 (unchanged idea)
    - type: object
      required: [action, bapId, bapUri, messageId, timestamp, transactionId, version]
      properties:
        version: { type: string, const: "2.0.0" }
        # ... camelCase fields ...
      additionalProperties: false

    # Branch 1: v1.0 + exclusion of v2-shaped payloads
    - allOf:
        - type: object
          title: Context V1.0
          additionalProperties: true
          properties:
            bap_id: { type: string }
            # ... v1 fields ...
        - not:
            type: object
            description: Fingerprint of Context v2.0 required fields
            required: [action, bapId, bapUri, messageId, timestamp, transactionId, version]
            properties:
              version: { type: string, const: "2.0.0" }
              action: { type: string }
              bapId: { type: string }
              bapUri: { type: string, format: uri }
              messageId: { type: string, format: uuid }
              transactionId: { type: string, format: uuid }
              timestamp: { type: string, format: date-time }
```

**Note:** `anyOf` instead of `oneOf` does **not** fix the remote catalog `$ref` issue, and it **weakens** “exactly one v1 vs v2” semantics. Disjoint `oneOf` is the right fix here.

---

## Summary table

| Area | Before | Problem | After |
|------|--------|---------|--------|
| Legacy catalog in `CatalogPublishAction` | `$ref` to remote `Catalog/v2.0` inlines broken `#/components/...` | Compile / resolve errors, wrong graph edges | Local `CatalogV20` (or fixed remote URLs only) |
| `Context` `oneOf` | v1 too loose; overlaps v2 | Valid v2 fails `oneOf` | v1 wrapped with `not` v2 fingerprint |

---

## For implementers

- **CDS (Catalg)** loads the default raw URL for `beckn.yaml` (configurable via `BECKN_PROTOCOL_API_SCHEMA_URL`), bundles once per cache window, and validates publish payloads against `Context` + `CatalogPublishAction` from that graph.
- **Product rule:** Catalg may still **reject** `beckn:*` catalogs in application code even if the OpenAPI `oneOf` allows the legacy branch — that is an **interoperability profile**, not a contradiction of the spec file.

