### PR TITLE
Schema Update -  publishDirectives, push/pull/callback APIs, subscription cleanup, master search APIs update

### DIFF
--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -955,7 +955,7 @@ paths:
 
   /catalog/on_publish:
     post:
-      summary: summary: CDS returns per-catalog processing results to the BPP
+      summary: CDS returns per-catalog processing results to the BPP
       operationId: catalogOnPublish
       tags:
       - Catalog Publishing

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -906,12 +906,12 @@ paths:
 
   /catalog/publish:
     post:
-      summary: Publish catalogs to the network
-      description: >-
-        Submit one or more catalogs for indexing and distribution across the
-        network. Returns an immediate acknowledgement; per-catalog processing
-        results are delivered asynchronously via the `/catalog/on_publish`
-        callback.
+      summary: BPP publishes catalogs for indexing by a CDS
+      description: 'BPP submits one or more catalogs to be indexed by a Catalog Discovery Service (CDS).
+
+        Returns an **ACK** immediately if accepted for processing. The per-catalog processing
+
+        result arrives asynchronously via `/catalog/on_publish`.'
       operationId: catalogPublish
       tags:
       - Catalog Publishing
@@ -934,7 +934,9 @@ paths:
                     properties:
                       action:
                         type: string
-                        const: catalog/publish
+                        enum:
+                        - catalog/publish
+                        - catalog_publish
                 message:
                   $ref: '#/components/schemas/CatalogPublishAction'
       responses:
@@ -951,7 +953,7 @@ paths:
 
   /catalog/on_publish:
     post:
-      summary: Receive catalog publish results
+      summary: CDS returns per-catalog processing results to the BPP
       operationId: catalogOnPublish
       tags:
       - Catalog Publishing
@@ -974,7 +976,9 @@ paths:
                     properties:
                       action:
                         type: string
-                        const: catalog/on_publish
+                        enum:
+                        - on_catalog_publish
+                        - catalog/on_publish
                 message:
                   $ref: '#/components/schemas/CatalogOnPublishAction'
       responses:
@@ -993,9 +997,8 @@ paths:
       description: >-
         Sends a catalog directly to a known downstream participant.
         Unlike `/catalog/publish` which submits catalogs for network-wide
-        indexing, `/catalog/push` delivers to a single recipient.
-        Fire-and-forget — the receiver returns an ACK and no callback
-        follows.
+        indexing and distribution, `/catalog/push` delivers to a single
+        recipient.
       operationId: catalogPush
       tags:
       - Catalog Publishing

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -21,8 +21,6 @@ tags:
   description: Rate and support completed contracts
 - name: Catalog Publishing
   description: Publish and manage catalogs on a Beckn network
-- name: Catalog Distribution
-  description: Distribute catalogs between network participants
 - name: Subscription
   description: Subscribe to catalog updates across networks and schema types
 - name: Catalog Pull
@@ -995,15 +993,16 @@ paths:
 
   /catalog/push:
     post:
-      summary: Push pre-resolved catalogs to a discovery service
+      summary: Push a catalog to a downstream participant
       description: >-
-        Sends fully assembled, pre-resolved catalogs to a downstream discovery service.
-        Resources are already fully resolved — variants expanded, offers merged.
-        Returns an ACK immediately; processing is asynchronous.
-        No callback is defined for this action.
+        Sends a catalog directly from a BPP or Catalog Discovery Service to a specific
+        downstream Beckn participant. Unlike `/catalog/publish`, which offers a catalog
+        to a CDS for onward handling, `/catalog/push` targets a single known recipient
+        and is fire-and-forget — the receiver returns an ACK and no callback is defined
+        for this action.
       operationId: catalogPush
       tags:
-      - Catalog Distribution
+      - Catalog Publishing
       parameters:
       - $ref: '#/components/parameters/AuthorizationHeader'
       requestBody:
@@ -1297,8 +1296,16 @@ paths:
       - Catalog Pull
       parameters:
       - $ref: '#/components/parameters/AuthorizationHeader'
-      summary: Submit async catalog pull request
-      description: "Submits a catalog pull request and returns an immediate ACK with a\ngenerated `requestId`. The actual catalog data is delivered asynchronously via\nHTTP callback to `{context.bapUri}/on_catalog_pull`.\n\n**Required fields:** `context.version`, `context.action`, `context.bapUri`,\n`message.mode`.\n\n**FULL mode:** returns the latest version of each catalog matching the filters.\n\n**INCREMENTAL mode:** returns all catalog versions published between\n`message.fromDate` and `message.toDate` (ISO-8601, inclusive). Multiple entries\nper catalogId are possible, ordered newest first.\n\nFor large result sets, the callback body contains an `objectUrl` field pointing\nto `GET /catalog/pull/result/{requestId}` where the full payload can be downloaded.\n"
+      summary: Pull catalogs on demand
+      description: >-
+        Requests one or more catalogs from a Catalog Discovery Service. The BAP sends
+        the pull request and receives an immediate ACK with a `requestId`; the catalogs
+        are delivered asynchronously via callback to `{context.bapUri}/on_catalog_pull`.
+
+
+        Two modes are supported: `FULL` returns the latest version of each catalog
+        matching the request filters; `INCREMENTAL` returns catalog versions published
+        within the supplied `fromDate`/`toDate` window.
       requestBody:
         required: true
         content:
@@ -1359,8 +1366,11 @@ paths:
           type: string
           pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
         example: f47ac10b-58cc-4372-a567-0e02b2c3d479
-      summary: Download large pull result
-      description: "Downloads a pull result by its request ID. Call this endpoint after receiving\na callback that contains a non-null `message.objectUrl` field.\n\nThe response body contains a flat `catalogs[]` array with `pagination` metadata,\nidentical in structure to the inline callback.\n\n`requestId` must be a valid UUID v4. Invalid formats return HTTP 400.\n"
+      summary: Retrieve catalogs for a pull request
+      description: >-
+        Retrieves the catalogs associated with a previously acknowledged pull request,
+        identified by its `requestId`. The response carries the same `catalogs[]` and
+        `pagination` structure as the asynchronous callback.
       responses:
         '200':
           description: Pull result as JSON

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -45,16 +45,24 @@ tags:
 
     Two delivery modes:
 
-    - **FULL** — latest version of each matching catalog
+    - **FULL** — latest version of each matching catalog (from cache, git fallback)
 
-    - **INCREMENTAL** — all versions within a date range (`fromDate`/`toDate`)
+    - **INCREMENTAL** — all historical versions within a date range from git history;
+    multiple entries per catalogId possible, ordered newest first
 
 
-    Large payloads exceeding the configured inline threshold are written to disk
+    Large payloads exceeding the configured inline threshold are served via
 
-    and served via `GET /catalog/pull/result/{requestId}/catalogs.json`; the
+    `GET /catalog/pull/result/{requestId}`; the callback''s `objectUrl` field
 
-    callback''s `objectUrl` field carries the download URL and `sha256` checksum.
+    carries the download URL and `sha256` checksum.
+
+
+    Callback response follows standard Beckn envelope:
+
+    `{ context: { action: on_catalog_pull }, message: { requestId, status, catalogs[], pagination } }`
+
+    Catalogs are flat Catalog objects — no distribution envelope wrapping.
 
     '
 - name: Master Resource Search
@@ -1036,6 +1044,8 @@ paths:
         catalogs to a downstream discovery service. Resources are already resolved
         (master-wins merge applied, variants expanded, offers merged).
         Returns an ACK immediately if accepted for async processing.
+        This is a fire-and-forget pattern — no on_catalog_push callback is defined.
+        Processing failures are handled internally via Kafka retries and dead-letter topics.
       operationId: catalogPush
       tags:
       - Catalog Distribution
@@ -1341,7 +1351,7 @@ paths:
       parameters:
       - $ref: '#/components/parameters/AuthorizationHeader'
       summary: Submit async catalog pull request
-      description: "Accepts a pull request and returns an immediate HTTP 200 ACK with a\ngenerated `requestId`. Processing runs asynchronously on the\n`pullExecutor` thread pool.\n\nWhen processing completes, the Catalog Indexer Job POSTs to\n`{context.bapUri}/on_catalog_pull` with a `PullCallbackPayload`.\n\n**Required fields:** `context.version`, `context.action`, `context.bapUri`,\n`message.mode`.\n\n**FULL mode:** returns the latest version of each catalog matching the filters.\n\n**INCREMENTAL mode:** returns all catalog versions indexed between\n`message.fromDate` and `message.toDate` (ISO-8601, inclusive).\n\n**Payload size:**\n- Small (< inline threshold): catalogs returned inline in the callback body.\n- Large (≥ inline threshold): callback contains an `objectUrl` pointing to\n  `GET /catalog/pull/result/{requestId}/catalogs.json`.\n"
+      description: "Accepts a pull request and returns an immediate HTTP 200 ACK with a\ngenerated `requestId`. Processing runs asynchronously.\n\nWhen processing completes, the Catalog Indexer Job POSTs to\n`{context.bapUri}/on_catalog_pull` with a standard Beckn envelope:\n`{ context: { action: on_catalog_pull }, message: { requestId, status, catalogs[], pagination } }`.\nCatalogs are flat Catalog objects — no distribution envelope wrapping.\n\n**Required fields:** `context.version`, `context.action`, `context.bapUri`,\n`message.mode`.\n\n**FULL mode:** returns the latest version of each catalog matching the\nfilters. Reads from cache (KVRocks) with git manifest fallback.\n\n**INCREMENTAL mode:** returns all historical catalog versions published\nbetween `message.fromDate` and `message.toDate` (ISO-8601, inclusive).\nReads from git commit history. Multiple entries per catalogId are possible\n(one per publish in the date range), ordered newest first. Capped at\n`maxHistoryPerCatalog` (default 100) versions per catalog.\n\n**Payload size:**\n- Small (< inline threshold): catalogs returned inline in the callback body.\n- Large (>= inline threshold): callback contains an `objectUrl` pointing to\n  `GET /catalog/pull/result/{requestId}`.\n\n**SSRF protection:** `context.bapUri` is validated before returning ACK.\nInvalid callback URLs are rejected immediately with a NACK.\n"
       requestBody:
         required: true
         content:
@@ -1387,7 +1397,7 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /catalog/pull/result/{requestId}/{filename}:
+  /catalog/pull/result/{requestId}:
     get:
       operationId: getPullResult
       tags:
@@ -1402,30 +1412,36 @@ paths:
           type: string
           pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
         example: f47ac10b-58cc-4372-a567-0e02b2c3d479
-      - name: filename
-        in: path
-        required: true
-        description: Result filename — must be `catalogs.json`
-        schema:
-          type: string
-          enum:
-          - catalogs.json
-        example: catalogs.json
-      summary: Download large pull result file
-      description: "Serves the result file written to disk when the pull payload exceeds the\nconfigured inline threshold. Called by the BAP after receiving a callback\nwith a non-null `message.objectUrl`.\n\n**Path traversal protection:**\n- `requestId` must match the UUID v4 pattern\n  (`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`).\n- `filename` is validated against an allowlist; only `catalogs.json` is permitted.\n\nRequests failing either check return HTTP 400 without a body.\n"
+      summary: Download large pull result
+      description: "Serves the pull result when the payload exceeds the configured inline\nthreshold. Called by the BAP after receiving a callback with a non-null\n`message.objectUrl`.\n\nThe response body has the same structure as the inline callback:\nflat `catalogs[]` array with `pagination` metadata.\n\n**Path traversal protection:**\n`requestId` must match the UUID v4 pattern. Invalid formats return HTTP 400.\n"
       responses:
         '200':
           description: Pull result as JSON
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PullResultFile'
+                type: object
+                properties:
+                  catalogs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Catalog'
+                    description: Flat Catalog objects (same shape as inline callback)
+                  pagination:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
         '400':
-          description: Invalid requestId format or disallowed filename
+          description: Invalid requestId format
         '401':
           $ref: '#/components/responses/NackUnauthorized'
         '404':
-          description: Result file not found (processing may still be in progress)
+          description: Result not found (processing may still be in progress)
 
   /catalog/master/search:
     post:
@@ -3350,22 +3366,6 @@ components:
           format: date-time
           description: Inclusive upper bound for INCREMENTAL mode
 
-    PullResultFile:
-      type: object
-      description: 'JSON body of `GET /catalog/pull/result/{requestId}/catalogs.json`.
-
-        Same structure as the inline `catalog` array in the callback payload —
-
-        a list of distribution-envelope catalog objects.
-
-        '
-      properties:
-        catalogs:
-          type: array
-          items:
-            type: object
-            description: Full catalog distribution envelope (context + message + meta)
-            additionalProperties: true
   responses:
     Ack:
       description: Synchronous receipt acknowledgement returned for every accepted Beckn request.

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -911,7 +911,7 @@ paths:
 
         Returns an **ACK** immediately if accepted for processing. The per-catalog processing
 
-        result arrives asynchronously via `/catalog/on_publish`.'
+        result arrives asynchronously via `/beckn/catalog/on_publish`.'
       operationId: catalogPublish
       tags:
       - Catalog Publishing

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -3284,8 +3284,10 @@ components:
     CatalogPullAction:
       type: object
       description: Message payload for catalog/pull
+      additionalProperties: false
       required:
       - mode
+      - filters
       properties:
         mode:
           type: string
@@ -3295,29 +3297,41 @@ components:
           description: "- `FULL` — returns the latest version of each matching catalog.\n- `INCREMENTAL` — returns all catalog versions indexed between\n  `fromDate` and `toDate` (inclusive).\n"
         filters:
           type: object
-          description: Optional filters narrowing which catalogs are returned
+          description: "Required filters scoping which catalogs are returned. At least\
+            \ one of catalogIds, networkIds, or schemaTypes must be provided with a\
+            \ non-empty array — an unscoped pull is rejected. When multiple fields\
+            \ are supplied they are ANDed together (intersection). Unknown fields\
+            \ are rejected."
+          additionalProperties: false
+          minProperties: 1
           properties:
+            catalogIds:
+              type: array
+              items:
+                type: string
+              minItems: 1
+              description: "Explicit catalog IDs to pull. When combined with networkIds\
+                \ or schemaTypes the result is the intersection of all constraints."
             networkIds:
               type: array
               items:
                 type: string
-              description: Filter by network IDs (empty = all networks)
-              default: []
+              minItems: 1
+              description: Filter by network IDs.
             schemaTypes:
               type: array
               items:
                 type: string
-              description: Filter by schema type URIs (empty = all types)
-              default: []
-        catalogIds:
-          type: array
-          items:
-            type: string
-          description: Explicit catalog IDs to pull (alternative to filters)
+              minItems: 1
+              description: Filter by schema type URIs.
         limit:
           type: integer
           minimum: 1
           description: Maximum number of catalogs to return (server may apply its own cap)
+        offset:
+          type: integer
+          minimum: 0
+          description: Zero-based page start for pagination
         fromDate:
           type: string
           format: date-time

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -1575,6 +1575,64 @@ components:
       - catalogs
       type: object
       properties:
+        publishDirectives:
+          description: Directives controlling publish behavior for master/regular catalog flow.
+          type: array
+          items:
+            type: object
+            required:
+            - catalogId
+            - catalogType
+            properties:
+              catalogId:
+                type: string
+                description: Identifier of the catalog to which these directives apply
+              catalogType:
+                type: string
+                enum:
+                - master
+                - regular
+                description: master = canonical source catalog; regular = seller/provider extension catalog
+              updateMode:
+                type: string
+                enum:
+                - FULL
+                - MERGE
+                default: FULL
+                description: Used for regular updates. FULL replaces overlay; MERGE applies JSON Merge Patch semantics.
+              resourceDirectives:
+                description: Optional per-resource extension mapping for regular catalogs
+                type: array
+                items:
+                  type: object
+                  required:
+                  - resourceId
+                  - extends
+                  properties:
+                    resourceId:
+                      type: string
+                      description: Seller/provider resource identifier in this catalog
+                    extends:
+                      type: object
+                      required:
+                      - masterResourceId
+                      properties:
+                        masterResourceId:
+                          type: string
+                          description: Canonical master resource identifier being extended
+                    variant:
+                      type: object
+                      additionalProperties: true
+                      properties:
+                        type:
+                          type: string
+                          description: Type of variant extension
+                        id:
+                          type: string
+                          description: Identifier for this specific variant
+                        label:
+                          type: string
+                          description: Human-readable label for the variant
         catalogs:
           type: array
           minItems: 1
@@ -1961,49 +2019,6 @@ components:
           description: Beckn Protocol API base URL of the BPP
           type: string
           format: uri
-        publishDirectives:
-          deprecated: true
-          description: Directives controlling publish behavior for master/regular catalog flow. Deprecated and planned for removal in a future release.
-          type: object
-          additionalProperties: false
-          required:
-          - catalogType
-          properties:
-            catalogType:
-              type: string
-              enum:
-              - master
-              - regular
-              description: master = canonical source catalog; regular = seller/provider extension catalog
-            updateMode:
-              type: string
-              enum:
-              - FULL
-              - MERGE
-              default: FULL
-              description: Used for regular updates. FULL replaces overlay; MERGE applies JSON Merge Patch semantics.
-            resourceDirectives:
-              description: Optional per-resource extension mapping for regular catalogs
-              type: array
-              items:
-                type: object
-                additionalProperties: false
-                required:
-                - resourceId
-                - extends
-                properties:
-                  resourceId:
-                    type: string
-                    description: Seller/provider resource identifier in this catalog
-                  extends:
-                    type: object
-                    additionalProperties: false
-                    required:
-                    - masterResourceId
-                    properties:
-                      masterResourceId:
-                        type: string
-                        description: Canonical master resource identifier being extended
         descriptor:
           description: Human / Agent-readable description of this catalog
           allOf:

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -1359,7 +1359,7 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /on_catalog_pull:
+  /catalog/on_pull:
     post:
       summary: Receive catalog pull results
       description: >-
@@ -1396,7 +1396,7 @@ paths:
                     properties:
                       action:
                         type: string
-                        const: on_catalog_pull
+                        const: catalog/on_pull
                 message:
                   $ref: '#/components/schemas/CatalogPullCallbackAction'
       responses:

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -1351,6 +1351,61 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /on_catalog_pull:
+    post:
+      summary: Receive an asynchronous pull result
+      description: >-
+        Hosted by the BAP at `{bapUri}/on_catalog_pull`. Invoked by the Catalog
+        Discovery Service as the asynchronous callback for a previously
+        acknowledged `/catalog/pull` request. The callback carries the final
+        state of the request — either the assembled catalogs (inline or via
+        `objectUrl`) or a terminal failure reason.
+
+
+        The BAP MUST deduplicate on `message.requestId`. The callback is
+        delivered with at-least-once semantics and may fire more than once if a
+        CDS instance restarts between completion and offset commit.
+
+
+        Deduplicated submissions (identical expensive request within the CDS
+        large-result dedup window, default 24 hours) do NOT fire a new callback
+        — the BAP should poll `GET /catalog/pull/result/{requestId}` instead.
+      operationId: onCatalogPull
+      tags:
+      - Catalog Pull
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required:
+              - context
+              - message
+              properties:
+                context:
+                  allOf:
+                  - $ref: '#/components/schemas/Context'
+                  - type: object
+                    properties:
+                      action:
+                        type: string
+                        const: on_catalog_pull
+                message:
+                  $ref: '#/components/schemas/CatalogPullCallbackAction'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /catalog/pull/result/{requestId}:
     get:
       operationId: getPullResult
@@ -3340,6 +3395,86 @@ components:
           type: string
           format: date-time
           description: Inclusive upper bound for INCREMENTAL mode
+
+    CatalogPullCallbackAction:
+      type: object
+      description: >-
+        Message payload for `on_catalog_pull`. Exactly one of `catalogs`
+        (inline) or `objectUrl` (fetch the full payload from the CDS) is
+        present when `status = COMPLETED`. Neither is present when
+        `status` is `FAILED` or `DLT_EXHAUSTED` — `error` carries the reason
+        instead.
+      additionalProperties: false
+      required:
+      - requestId
+      - status
+      properties:
+        requestId:
+          type: string
+          format: uuid
+          description: Echoes the `requestId` returned by the original `/catalog/pull` ACK.
+        status:
+          type: string
+          enum:
+          - COMPLETED
+          - FAILED
+          - DLT_EXHAUSTED
+        attempts:
+          type: integer
+          minimum: 1
+          description: Number of processing attempts. 1 for first-try success.
+        catalogs:
+          type: array
+          description: Inline catalog payload, present only for small results below the CDS inline threshold.
+          items:
+            type: object
+        objectUrl:
+          type: object
+          description: >-
+            Present when the result exceeds the inline threshold. BAP fetches
+            via GET on `url`. When the CDS is in signed-URL mode, `url` is
+            re-generated on every status poll with a fresh 15-minute expiry.
+          additionalProperties: false
+          required:
+          - url
+          - format
+          - sizeBytes
+          - checksum
+          properties:
+            url:
+              type: string
+              description: Either a CDS-hosted `/catalog/pull/result/{requestId}` URL or a pre-signed object store URL.
+            expiresAt:
+              type: string
+              format: date-time
+              description: Expiry for signed URLs; absent for CDS-hosted URLs.
+            format:
+              type: string
+              enum:
+              - json
+              - json.gz
+            sizeBytes:
+              type: integer
+              minimum: 0
+            checksum:
+              type: string
+              description: SHA-256 hex prefixed with `sha256:`.
+        pagination:
+          type: object
+          additionalProperties: false
+          properties:
+            total:
+              type: integer
+              minimum: 0
+            limit:
+              type: integer
+              minimum: 1
+            offset:
+              type: integer
+              minimum: 0
+        error:
+          description: Present only when `status != COMPLETED`.
+          $ref: '#/components/schemas/Error'
 
   responses:
     Ack:

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -24,7 +24,7 @@ tags:
 - name: Subscription
   description: Subscribe to catalog updates across networks and schema types
 - name: Catalog Pull
-  description: Pull catalogs on demand with full or incremental sync
+  description: Pull catalogs on demand — full snapshot or incremental updates delivered asynchronously
 - name: Master Resource Search
   description: Search and retrieve master resource definitions
 security: []

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -21,6 +21,8 @@ tags:
   description: Rate and support completed contracts
 - name: Catalog Publishing
   description: Publish catalogs to a Catalog Discovery Service (CDS)
+- name: Catalog Distribution
+  description: Push pre-resolved catalogs from a CDS to downstream discovery services
 - name: Subscription
   description: 'Beckn v2.0 catalog subscription management.
 
@@ -972,7 +974,6 @@ paths:
                         type: string
                         enum:
                         - catalog/publish
-                        - catalog_publish
                 message:
                   $ref: '#/components/schemas/CatalogPublishAction'
       responses:
@@ -1024,6 +1025,52 @@ paths:
           $ref: '#/components/responses/NackBadRequest'
         '401':
           $ref: '#/components/responses/NackUnauthorized'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /catalog/push:
+    post:
+      summary: Push pre-resolved catalogs to a discovery service
+      description: >-
+        A Catalog Discovery Service (CDS) pushes fully assembled, pre-resolved
+        catalogs to a downstream discovery service. Resources are already resolved
+        (master-wins merge applied, variants expanded, offers merged).
+        Returns an ACK immediately if accepted for async processing.
+      operationId: catalogPush
+      tags:
+      - Catalog Distribution
+      parameters:
+      - $ref: '#/components/parameters/AuthorizationHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - context
+              - message
+              properties:
+                context:
+                  allOf:
+                  - $ref: '#/components/schemas/Context'
+                  - type: object
+                    properties:
+                      action:
+                        type: string
+                        enum:
+                        - catalog/push
+                message:
+                  $ref: '#/components/schemas/CatalogPublishAction'
+      responses:
+        '200':
+          $ref: '#/components/responses/Ack'
+        '400':
+          $ref: '#/components/responses/NackBadRequest'
+        '401':
+          $ref: '#/components/responses/NackUnauthorized'
+        '409':
+          $ref: '#/components/responses/AckNoCallback'
         '500':
           $ref: '#/components/responses/ServerError'
 
@@ -1598,7 +1645,7 @@ components:
                 enum:
                 - FULL
                 - MERGE
-                default: FULL
+                default: MERGE
                 description: Used for regular updates. FULL replaces overlay; MERGE applies JSON Merge Patch semantics.
               resourceDirectives:
                 description: Optional per-resource extension mapping for regular catalogs

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -20,59 +20,15 @@ tags:
 - name: Post-Fulfillment
   description: Rate and support completed contracts
 - name: Catalog Publishing
-  description: Publish catalogs to a Catalog Discovery Service (CDS)
+  description: Publish and manage catalogs on a Beckn network
 - name: Catalog Distribution
-  description: Push pre-resolved catalogs from a CDS to downstream discovery services
+  description: Distribute catalogs between network participants
 - name: Subscription
-  description: 'Beckn v2.0 catalog subscription management.
-
-    Subscriptions determine which networks and schema types a BAP receives
-
-    `on_discover` callbacks for. Only `ACTIVE` subscriptions are matched
-
-    during evaluation.
-
-    '
+  description: Subscribe to catalog updates across networks and schema types
 - name: Catalog Pull
-  description: 'Async catalog pull API hosted on the Catalog Indexer Job.
-
-    The BAP POSTs a pull request and receives an immediate ACK with a `requestId`.
-
-    The actual catalog data is delivered asynchronously via HTTP callback to
-
-    `{bapUri}/on_catalog_pull`.
-
-
-    Two delivery modes:
-
-    - **FULL** — latest version of each matching catalog (from cache, git fallback)
-
-    - **INCREMENTAL** — all historical versions within a date range from git history;
-    multiple entries per catalogId possible, ordered newest first
-
-
-    Large payloads exceeding the configured inline threshold are served via
-
-    `GET /catalog/pull/result/{requestId}`; the callback''s `objectUrl` field
-
-    carries the download URL and `sha256` checksum.
-
-
-    Callback response follows standard Beckn envelope:
-
-    `{ context: { action: on_catalog_pull }, message: { requestId, status, catalogs[], pagination } }`
-
-    Catalogs are flat Catalog objects — no distribution envelope wrapping.
-
-    '
+  description: Pull catalogs on demand with full or incremental sync
 - name: Master Resource Search
-  description: 'Query APIs for master catalog items stored in the Catalog Indexer git
-
-    repository. All endpoints return a Beckn v2.0 response envelope with
-
-    `action: "on_catalog_master_search"`.
-
-    '
+  description: Search and retrieve master resource definitions
 security: []
 servers:
 - url: https://{subscriberUrl}
@@ -998,7 +954,10 @@ paths:
 
   /catalog/on_publish:
     post:
-      summary: CDS returns per-catalog processing results to the BPP
+      summary: Callback — return per-catalog processing results to the BPP
+      description: 'Delivers the per-catalog processing outcome for each catalog submitted
+        via `/catalog/publish`. Each result indicates whether the catalog was accepted,
+        rejected, or partially processed, along with any validation errors.'
       operationId: catalogOnPublish
       tags:
       - Catalog Publishing
@@ -1040,12 +999,10 @@ paths:
     post:
       summary: Push pre-resolved catalogs to a discovery service
       description: >-
-        A Catalog Discovery Service (CDS) pushes fully assembled, pre-resolved
-        catalogs to a downstream discovery service. Resources are already resolved
-        (master-wins merge applied, variants expanded, offers merged).
-        Returns an ACK immediately if accepted for async processing.
-        This is a fire-and-forget pattern — no on_catalog_push callback is defined.
-        Processing failures are handled internally via Kafka retries and dead-letter topics.
+        Sends fully assembled, pre-resolved catalogs to a downstream discovery service.
+        Resources are already fully resolved — variants expanded, offers merged.
+        Returns an ACK immediately; processing is asynchronous.
+        No callback is defined for this action.
       operationId: catalogPush
       tags:
       - Catalog Distribution
@@ -1092,20 +1049,11 @@ paths:
       - Subscription
       parameters:
       - $ref: '#/components/parameters/AuthorizationHeader'
-      description: 'Creates a new catalog subscription using the Beckn v2.0 envelope
+      description: 'Creates a new catalog subscription. The subscriber receives catalog
+        update callbacks at the URL specified in `callbackUrl` (defaults to `context.bapUri`).
 
-        (`action: "catalog/subscription"`). The subscriber identity is derived
-
-        from `context.bapId` / `context.bapUri`; the callback URL defaults
-
-        to `bapUri`.
-
-
-        At least one of `networkIds` or `schemaTypes` must be non-empty.
-
-        An empty `schemaTypes` array is treated as the wildcard sentinel `"*"`,
-
-        matching all schema types for the specified networks.
+        At least `networkIds` must be provided. Omitting `schemaTypes` or providing an empty
+        array subscribes to all schema types on the specified networks.
 
         '
       requestBody:
@@ -1185,6 +1133,8 @@ paths:
   /catalog/subscriptions:
     get:
       summary: List subscriptions for a subscriber
+      description: 'Returns all subscriptions belonging to the given subscriber, with pagination.
+        Use the `subscriberId` query parameter to scope results to a specific BAP.'
       operationId: catalogSubscribeList
       tags:
       - Subscription
@@ -1193,7 +1143,7 @@ paths:
       - name: subscriberId
         in: query
         required: true
-        description: BAP URI, BAP ID, or internal subscriber UUID
+        description: Subscriber identifier — typically the BAP ID or BAP URI used when creating the subscription
         schema:
           type: string
         example: https://bap.example.com
@@ -1235,6 +1185,8 @@ paths:
   /catalog/subscription/{subscriptionId}:
     get:
       summary: Get subscription by ID
+      description: 'Returns the full details of a single subscription, including its network scope,
+        schema type filters, callback URL, status, and delivery policy.'
       operationId: catalogSubscribeGet
       tags:
       - Subscription
@@ -1289,11 +1241,8 @@ paths:
       operationId: catalogSubscribeDelete
       tags:
       - Subscription
-      description: 'Soft-deletes a subscription by setting its status to `DELETED`.
-
-        The subscription record is retained in the database; it will no longer
-
-        receive catalog delivery callbacks.
+      description: 'Deactivates a subscription. The subscription will no longer receive
+        catalog delivery callbacks. The subscription record is returned with status `DELETED`.
 
         '
       parameters:
@@ -1351,7 +1300,7 @@ paths:
       parameters:
       - $ref: '#/components/parameters/AuthorizationHeader'
       summary: Submit async catalog pull request
-      description: "Accepts a pull request and returns an immediate HTTP 200 ACK with a\ngenerated `requestId`. Processing runs asynchronously.\n\nWhen processing completes, the Catalog Indexer Job POSTs to\n`{context.bapUri}/on_catalog_pull` with a standard Beckn envelope:\n`{ context: { action: on_catalog_pull }, message: { requestId, status, catalogs[], pagination } }`.\nCatalogs are flat Catalog objects — no distribution envelope wrapping.\n\n**Required fields:** `context.version`, `context.action`, `context.bapUri`,\n`message.mode`.\n\n**FULL mode:** returns the latest version of each catalog matching the\nfilters. Reads from cache (KVRocks) with git manifest fallback.\n\n**INCREMENTAL mode:** returns all historical catalog versions published\nbetween `message.fromDate` and `message.toDate` (ISO-8601, inclusive).\nReads from git commit history. Multiple entries per catalogId are possible\n(one per publish in the date range), ordered newest first. Capped at\n`maxHistoryPerCatalog` (default 100) versions per catalog.\n\n**Payload size:**\n- Small (< inline threshold): catalogs returned inline in the callback body.\n- Large (>= inline threshold): callback contains an `objectUrl` pointing to\n  `GET /catalog/pull/result/{requestId}`.\n\n**SSRF protection:** `context.bapUri` is validated before returning ACK.\nInvalid callback URLs are rejected immediately with a NACK.\n"
+      description: "Submits a catalog pull request and returns an immediate ACK with a\ngenerated `requestId`. The actual catalog data is delivered asynchronously via\nHTTP callback to `{context.bapUri}/on_catalog_pull`.\n\n**Required fields:** `context.version`, `context.action`, `context.bapUri`,\n`message.mode`.\n\n**FULL mode:** returns the latest version of each catalog matching the filters.\n\n**INCREMENTAL mode:** returns all catalog versions published between\n`message.fromDate` and `message.toDate` (ISO-8601, inclusive). Multiple entries\nper catalogId are possible, ordered newest first.\n\nFor large result sets, the callback body contains an `objectUrl` field pointing\nto `GET /catalog/pull/result/{requestId}` where the full payload can be downloaded.\n"
       requestBody:
         required: true
         content:
@@ -1413,7 +1362,7 @@ paths:
           pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
         example: f47ac10b-58cc-4372-a567-0e02b2c3d479
       summary: Download large pull result
-      description: "Serves the pull result when the payload exceeds the configured inline\nthreshold. Called by the BAP after receiving a callback with a non-null\n`message.objectUrl`.\n\nThe response body has the same structure as the inline callback:\nflat `catalogs[]` array with `pagination` metadata.\n\n**Path traversal protection:**\n`requestId` must match the UUID v4 pattern. Invalid formats return HTTP 400.\n"
+      description: "Downloads a pull result by its request ID. Call this endpoint after receiving\na callback that contains a non-null `message.objectUrl` field.\n\nThe response body contains a flat `catalogs[]` array with `pagination` metadata,\nidentical in structure to the inline callback.\n\n`requestId` must be a valid UUID v4. Invalid formats return HTTP 400.\n"
       responses:
         '200':
           description: Pull result as JSON
@@ -1445,7 +1394,10 @@ paths:
 
   /catalog/master/search:
     post:
-      summary: Search master catalog items
+      summary: Search master resource definitions
+      description: 'Searches canonical master resource definitions by network and schema type.
+        Returns matching resources grouped by catalog, with pagination. An empty `networkIds`
+        or `schemaTypes` list matches all values for that dimension.'
       operationId: masterSearch
       tags:
       - Master Resource Search
@@ -1512,7 +1464,9 @@ paths:
 
   /catalog/master/schemaTypes:
     get:
-      summary: List distinct schema types
+      summary: List available master resource schema types
+      description: 'Returns the list of distinct schema type URIs for all master resources
+        currently available. Use these values to populate `schemaTypes` filters in search requests.'
       operationId: listMasterSchemaTypes
       tags:
       - Master Resource Search
@@ -1553,7 +1507,10 @@ paths:
 
   /catalog/master/{masterItemId}:
     get:
-      summary: Get single master item
+      summary: Get a master resource by ID
+      description: 'Returns a single master resource wrapped in its catalog envelope.
+        The response contains the full resource definition along with catalog-level
+        metadata such as provider and descriptor.'
       operationId: getMasterItem
       tags:
       - Master Resource Search
@@ -1662,7 +1619,7 @@ components:
                 - FULL
                 - MERGE
                 default: MERGE
-                description: Used for regular updates. FULL replaces overlay; MERGE applies JSON Merge Patch semantics.
+                description: 'FULL replaces all existing resources for this catalog with the incoming set. MERGE upserts incoming resources while preserving existing ones not present in this publish.'
               resourceDirectives:
                 description: Optional per-resource extension mapping for regular catalogs
                 type: array
@@ -3167,13 +3124,9 @@ components:
 
     CatalogSubscribeAction:
       type: object
-      description: 'Message payload for catalog/subscription.
-
-        At least one of `networkIds` or `schemaTypes` must be non-empty.
-
-        An empty `schemaTypes` array is treated as the wildcard sentinel `"*"`,
-
-        matching all schema types for the specified networks.
+      description: 'Message payload for catalog/subscription. At least `networkIds` must
+        be provided. Omitting `schemaTypes` or providing an empty array subscribes to all
+        schema types on the specified networks.
 
         '
       required:
@@ -3259,7 +3212,7 @@ components:
             maxRetries:
               type: integer
               default: 5
-              description: Maximum retry attempts before sending to DLT
+              description: Maximum number of delivery retry attempts
             initialDelaySeconds:
               type: integer
               default: 5

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -906,12 +906,12 @@ paths:
 
   /catalog/publish:
     post:
-      summary: BPP publishes catalogs for indexing by a CDS
-      description: 'BPP submits one or more catalogs to be indexed by a Catalog Discovery Service (CDS).
-
-        Returns an **ACK** immediately if accepted for processing. The per-catalog processing
-
-        result arrives asynchronously via `/beckn/catalog/on_publish`.'
+      summary: Publish catalogs to the network
+      description: >-
+        Submit one or more catalogs for indexing and distribution across the
+        network. Returns an immediate acknowledgement; per-catalog processing
+        results are delivered asynchronously via the `/catalog/on_publish`
+        callback.
       operationId: catalogPublish
       tags:
       - Catalog Publishing
@@ -934,9 +934,7 @@ paths:
                     properties:
                       action:
                         type: string
-                        enum:
-                        - catalog/publish
-                        - catalog_publish
+                        const: catalog/publish
                 message:
                   $ref: '#/components/schemas/CatalogPublishAction'
       responses:
@@ -953,7 +951,7 @@ paths:
 
   /catalog/on_publish:
     post:
-      summary: CDS returns per-catalog processing results to the BPP
+      summary: Receive catalog publish results
       operationId: catalogOnPublish
       tags:
       - Catalog Publishing
@@ -976,9 +974,7 @@ paths:
                     properties:
                       action:
                         type: string
-                        enum:
-                        - on_catalog_publish
-                        - catalog/on_publish
+                        const: catalog/on_publish
                 message:
                   $ref: '#/components/schemas/CatalogOnPublishAction'
       responses:
@@ -993,13 +989,13 @@ paths:
 
   /catalog/push:
     post:
-      summary: Push a catalog to a downstream participant
+      summary: Push a catalog to a specific participant
       description: >-
-        Sends a catalog directly from a BPP or Catalog Discovery Service to a specific
-        downstream Beckn participant. Unlike `/catalog/publish`, which offers a catalog
-        to a CDS for onward handling, `/catalog/push` targets a single known recipient
-        and is fire-and-forget — the receiver returns an ACK and no callback is defined
-        for this action.
+        Sends a catalog directly to a known downstream participant.
+        Unlike `/catalog/publish` which submits catalogs for network-wide
+        indexing, `/catalog/push` delivers to a single recipient.
+        Fire-and-forget — the receiver returns an ACK and no callback
+        follows.
       operationId: catalogPush
       tags:
       - Catalog Publishing
@@ -1040,19 +1036,19 @@ paths:
 
   /catalog/subscription:
     post:
-      summary: Subscribe to catalog distribution events
+      summary: Subscribe to catalog updates
       operationId: catalogSubscribe
       tags:
       - Subscription
       parameters:
       - $ref: '#/components/parameters/AuthorizationHeader'
-      description: 'Creates a new catalog subscription. The subscriber receives catalog
-        update callbacks at the URL specified in `callbackUrl` (defaults to `context.bapUri`).
-
-        At least `networkIds` must be provided. Omitting `schemaTypes` or providing an empty
-        array subscribes to all schema types on the specified networks.
-
-        '
+      description: >-
+        Creates a subscription to receive catalog updates for specified
+        networks and schema types. When matching catalogs are published,
+        the subscriber receives callbacks at the provided `callbackUrl`
+        (defaults to `context.bapUri`). At least one network must be
+        specified; omitting `schemaTypes` subscribes to all types on
+        those networks.
       requestBody:
         required: true
         content:
@@ -1129,9 +1125,11 @@ paths:
 
   /catalog/subscriptions:
     get:
-      summary: List subscriptions for a subscriber
-      description: 'Returns all subscriptions belonging to the given subscriber, with pagination.
-        Use the `subscriberId` query parameter to scope results to a specific BAP.'
+      summary: List subscriptions
+      description: >-
+        Returns all subscriptions belonging to the caller, with
+        pagination. Use the `subscriberId` query parameter to identify
+        the subscriber.
       operationId: catalogSubscribeList
       tags:
       - Subscription
@@ -1181,9 +1179,11 @@ paths:
 
   /catalog/subscription/{subscriptionId}:
     get:
-      summary: Get subscription by ID
-      description: 'Returns the full details of a single subscription, including its network scope,
-        schema type filters, callback URL, status, and delivery policy.'
+      summary: Get a subscription
+      description: >-
+        Returns the full details of a single subscription — network
+        scope, schema type filters, callback URL, status, and delivery
+        policy. Only the subscription owner can access it.
       operationId: catalogSubscribeGet
       tags:
       - Subscription
@@ -1229,19 +1229,21 @@ paths:
           $ref: '#/components/responses/NackBadRequest'
         '401':
           $ref: '#/components/responses/NackUnauthorized'
+        '403':
+          $ref: '#/components/responses/NackForbidden'
         '404':
           $ref: '#/components/responses/NackBadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:
-      summary: Delete (deactivate) subscription
+      summary: Delete a subscription
       operationId: catalogSubscribeDelete
       tags:
       - Subscription
-      description: 'Deactivates a subscription. The subscription will no longer receive
-        catalog delivery callbacks. The subscription record is returned with status `DELETED`.
-
-        '
+      description: >-
+        Deactivates a subscription so it no longer receives catalog
+        update callbacks. The subscription record is retained with
+        status `DELETED`. Only the subscription owner can delete it.
       parameters:
       - $ref: '#/components/parameters/AuthorizationHeader'
       - name: subscriptionId
@@ -1284,6 +1286,8 @@ paths:
           $ref: '#/components/responses/NackBadRequest'
         '401':
           $ref: '#/components/responses/NackUnauthorized'
+        '403':
+          $ref: '#/components/responses/NackForbidden'
         '404':
           $ref: '#/components/responses/NackBadRequest'
         '500':
@@ -1298,14 +1302,15 @@ paths:
       - $ref: '#/components/parameters/AuthorizationHeader'
       summary: Pull catalogs on demand
       description: >-
-        Requests one or more catalogs from a Catalog Discovery Service. The BAP sends
-        the pull request and receives an immediate ACK with a `requestId`; the catalogs
-        are delivered asynchronously via callback to `{context.bapUri}/on_catalog_pull`.
+        Request catalogs matching the specified filters. Returns an
+        immediate acknowledgement with a `requestId`; the actual
+        catalogs are delivered asynchronously to your callback URL.
 
 
-        Two modes are supported: `FULL` returns the latest version of each catalog
-        matching the request filters; `INCREMENTAL` returns catalog versions published
-        within the supplied `fromDate`/`toDate` window.
+        Two modes: **FULL** returns the latest version of each matching
+        catalog. **INCREMENTAL** returns all versions published within
+        the given date range, useful for syncing changes since your
+        last pull.
       requestBody:
         required: true
         content:
@@ -1353,23 +1358,18 @@ paths:
 
   /on_catalog_pull:
     post:
-      summary: Receive an asynchronous pull result
+      summary: Receive catalog pull results
       description: >-
-        Hosted by the BAP at `{bapUri}/on_catalog_pull`. Invoked by the Catalog
-        Discovery Service as the asynchronous callback for a previously
-        acknowledged `/catalog/pull` request. The callback carries the final
-        state of the request — either the assembled catalogs (inline or via
-        `objectUrl`) or a terminal failure reason.
+        Callback endpoint hosted by the BAP. After the BAP submits a
+        `/catalog/pull` request, the Catalog Discovery Service delivers
+        the results here asynchronously. The callback carries the final
+        outcome — assembled catalogs (inline or via a pre-signed
+        `objectUrl`) on success, or an error reason on failure.
 
 
-        The BAP MUST deduplicate on `message.requestId`. The callback is
-        delivered with at-least-once semantics and may fire more than once if a
-        CDS instance restarts between completion and offset commit.
-
-
-        Deduplicated submissions (identical expensive request within the CDS
-        large-result dedup window, default 24 hours) do NOT fire a new callback
-        — the BAP should poll `GET /catalog/pull/result/{requestId}` instead.
+        The callback is delivered with at-least-once semantics; the BAP
+        MUST deduplicate on `message.requestId` to handle retries
+        gracefully.
       operationId: onCatalogPull
       tags:
       - Catalog Pull
@@ -1408,10 +1408,12 @@ paths:
 
   /catalog/master/search:
     post:
-      summary: Search master resource definitions
-      description: 'Searches canonical master resource definitions by network and schema type.
-        Returns matching resources grouped by catalog, with pagination. An empty `networkIds`
-        or `schemaTypes` list matches all values for that dimension.'
+      summary: Search master resources
+      description: >-
+        Search for canonical master resource definitions across
+        networks. Filter by network and schema type; results are
+        grouped by catalog with pagination. Omitting a filter matches
+        all values for that dimension.
       operationId: masterSearch
       tags:
       - Master Resource Search
@@ -1478,9 +1480,11 @@ paths:
 
   /catalog/master/schemaTypes:
     get:
-      summary: List available master resource schema types
-      description: 'Returns the list of distinct schema type URIs for all master resources
-        currently available. Use these values to populate `schemaTypes` filters in search requests.'
+      summary: List master resource schema types
+      description: >-
+        Returns the distinct schema type URIs available across all
+        master resources. Use these values to populate the
+        `schemaTypes` filter in search requests.
       operationId: listMasterSchemaTypes
       tags:
       - Master Resource Search
@@ -1521,10 +1525,10 @@ paths:
 
   /catalog/master/{masterItemId}:
     get:
-      summary: Get a master resource by ID
-      description: 'Returns a single master resource wrapped in its catalog envelope.
-        The response contains the full resource definition along with catalog-level
-        metadata such as provider and descriptor.'
+      summary: Get a master resource
+      description: >-
+        Returns a single master resource by its identifier, wrapped in
+        its catalog envelope with full provider and descriptor metadata.
       operationId: getMasterItem
       tags:
       - Master Resource Search
@@ -3129,6 +3133,18 @@ components:
           error:
             $ref: '#/components/schemas/Error'
 
+    NackForbidden:
+      description: Caller is authenticated but does not have permission to access or modify this resource.
+      allOf:
+      - $ref: '#/components/schemas/Ack'
+      - type: object
+        properties:
+          status:
+            type: string
+            const: NACK
+          error:
+            $ref: '#/components/schemas/Error'
+
     ServerError:
       description: Internal failure on the network participant's application; the request could not be processed. The response body MAY contain an `error` object with additional details.
       type: object
@@ -3138,11 +3154,11 @@ components:
 
     CatalogSubscribeAction:
       type: object
-      description: 'Message payload for catalog/subscription. At least `networkIds` must
-        be provided. Omitting `schemaTypes` or providing an empty array subscribes to all
-        schema types on the specified networks.
-
-        '
+      description: >-
+        Subscription request payload. Specifies which networks and
+        schema types the subscriber wants to receive catalog updates
+        for. At least one network must be provided; omitting schema
+        types subscribes to all types on those networks.
       required:
       - subscription
       properties:
@@ -3256,7 +3272,9 @@ components:
 
     MasterSearchAction:
       type: object
-      description: Message payload for catalog/master_search
+      description: >-
+        Search request payload for master resources. Filter by network
+        and schema type; omit a filter to match all values.
       properties:
         filters:
           type: object
@@ -3289,7 +3307,9 @@ components:
 
     CatalogPullAction:
       type: object
-      description: Message payload for catalog/pull
+      description: >-
+        Pull request payload specifying which catalogs to retrieve and
+        in which mode (FULL or INCREMENTAL).
       additionalProperties: false
       required:
       - mode
@@ -3303,11 +3323,11 @@ components:
           description: "- `FULL` — returns the latest version of each matching catalog.\n- `INCREMENTAL` — returns all catalog versions indexed between\n  `fromDate` and `toDate` (inclusive).\n"
         filters:
           type: object
-          description: "Required filters scoping which catalogs are returned. At least\
-            \ one of catalogIds, networkIds, or schemaTypes must be provided with a\
-            \ non-empty array — an unscoped pull is rejected. When multiple fields\
-            \ are supplied they are ANDed together (intersection). Unknown fields\
-            \ are rejected."
+          description: >-
+            Filters scoping which catalogs are returned. At least one
+            of catalogIds, networkIds, or schemaTypes must be provided.
+            When multiple filters are supplied they are combined
+            (intersection).
           additionalProperties: false
           minProperties: 1
           properties:
@@ -3350,16 +3370,12 @@ components:
     CatalogPullCallbackAction:
       type: object
       description: >-
-        Message payload for `on_catalog_pull`. Delivered with at-least-once
-        semantics — the CDS may redeliver a callback if it crashes between
-        sending and committing the Kafka offset. The BAP MUST deduplicate on
-        `requestId`.
-
-
-        Exactly one of `catalogs` (inline, for small results) or `objectUrl`
-        (pre-signed object-store URL, for large results) is present when
-        `status = COMPLETED`. Neither is present when `status = FAILED` —
-        `error` carries the reason instead.
+        Callback payload for pull results. Contains either the
+        requested catalogs inline or a download URL for large results.
+        Delivered with at-least-once semantics — the BAP must
+        deduplicate on `requestId`. On success (`COMPLETED`), exactly
+        one of `catalogs` or `objectUrl` is present. On failure
+        (`FAILED`), `error` carries the reason.
       additionalProperties: false
       required:
       - requestId
@@ -3455,6 +3471,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/NackUnauthorized'
+    NackForbidden:
+      description: Caller is authenticated but does not have permission to access or modify this resource.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NackForbidden'
     ServerError:
       description: Internal failure on the network participant's application; the request could not be processed. The response body MAY contain an `error` object with additional details.
       content:

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -938,6 +938,7 @@ paths:
                         type: string
                         enum:
                         - catalog/publish
+                        - catalog_publish
                 message:
                   $ref: '#/components/schemas/CatalogPublishAction'
       responses:
@@ -954,10 +955,7 @@ paths:
 
   /catalog/on_publish:
     post:
-      summary: Callback — return per-catalog processing results to the BPP
-      description: 'Delivers the per-catalog processing outcome for each catalog submitted
-        via `/catalog/publish`. Each result indicates whether the catalog was accepted,
-        rejected, or partially processed, along with any validation errors.'
+      summary: summary: CDS returns per-catalog processing results to the BPP
       operationId: catalogOnPublish
       tags:
       - Catalog Publishing

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -1406,55 +1406,6 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /catalog/pull/result/{requestId}:
-    get:
-      operationId: getPullResult
-      tags:
-      - Catalog Pull
-      parameters:
-      - $ref: '#/components/parameters/AuthorizationHeader'
-      - name: requestId
-        in: path
-        required: true
-        description: UUID v4 returned in the pull ACK response
-        schema:
-          type: string
-          pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
-        example: f47ac10b-58cc-4372-a567-0e02b2c3d479
-      summary: Retrieve catalogs for a pull request
-      description: >-
-        Retrieves the catalogs associated with a previously acknowledged pull request,
-        identified by its `requestId`. The response carries the same `catalogs[]` and
-        `pagination` structure as the asynchronous callback.
-      responses:
-        '200':
-          description: Pull result as JSON
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  catalogs:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Catalog'
-                    description: Flat Catalog objects (same shape as inline callback)
-                  pagination:
-                    type: object
-                    properties:
-                      total:
-                        type: integer
-                      limit:
-                        type: integer
-                      offset:
-                        type: integer
-        '400':
-          description: Invalid requestId format
-        '401':
-          $ref: '#/components/responses/NackUnauthorized'
-        '404':
-          description: Result not found (processing may still be in progress)
-
   /catalog/master/search:
     post:
       summary: Search master resource definitions
@@ -3399,11 +3350,16 @@ components:
     CatalogPullCallbackAction:
       type: object
       description: >-
-        Message payload for `on_catalog_pull`. Exactly one of `catalogs`
-        (inline) or `objectUrl` (fetch the full payload from the CDS) is
-        present when `status = COMPLETED`. Neither is present when
-        `status` is `FAILED` or `DLT_EXHAUSTED` — `error` carries the reason
-        instead.
+        Message payload for `on_catalog_pull`. Delivered with at-least-once
+        semantics — the CDS may redeliver a callback if it crashes between
+        sending and committing the Kafka offset. The BAP MUST deduplicate on
+        `requestId`.
+
+
+        Exactly one of `catalogs` (inline, for small results) or `objectUrl`
+        (pre-signed object-store URL, for large results) is present when
+        `status = COMPLETED`. Neither is present when `status = FAILED` —
+        `error` carries the reason instead.
       additionalProperties: false
       required:
       - requestId
@@ -3418,11 +3374,7 @@ components:
           enum:
           - COMPLETED
           - FAILED
-          - DLT_EXHAUSTED
-        attempts:
-          type: integer
-          minimum: 1
-          description: Number of processing attempts. 1 for first-try success.
+          description: Terminal status only. There is no intermediate `PROCESSING` state — the callback fires exactly once (logically) per terminal outcome.
         catalogs:
           type: array
           description: Inline catalog payload, present only for small results below the CDS inline threshold.
@@ -3431,23 +3383,25 @@ components:
         objectUrl:
           type: object
           description: >-
-            Present when the result exceeds the inline threshold. BAP fetches
-            via GET on `url`. When the CDS is in signed-URL mode, `url` is
-            re-generated on every status poll with a fresh 15-minute expiry.
+            Present when the result exceeds the inline threshold. The BAP
+            fetches the payload by HTTP GET on `url`, which points directly at
+            a pre-signed object-store location (e.g. GCS V4 signed URL). The
+            CDS does not proxy the download.
           additionalProperties: false
           required:
           - url
           - format
           - sizeBytes
           - checksum
+          - expiresAt
           properties:
             url:
               type: string
-              description: Either a CDS-hosted `/catalog/pull/result/{requestId}` URL or a pre-signed object store URL.
+              description: Pre-signed object-store URL. Short-lived (typically 15 minutes).
             expiresAt:
               type: string
               format: date-time
-              description: Expiry for signed URLs; absent for CDS-hosted URLs.
+              description: URL expiry timestamp.
             format:
               type: string
               enum:
@@ -3473,7 +3427,7 @@ components:
               type: integer
               minimum: 0
         error:
-          description: Present only when `status != COMPLETED`.
+          description: Present only when `status = FAILED`.
           $ref: '#/components/schemas/Error'
 
   responses:


### PR DESCRIPTION
## Summary

Comprehensive update to the Beckn Protocol v2.0.0 OpenAPI specification aligning the catalog management APIs with the reference implementation.

### publishDirectives restructured
- Moved `publishDirectives` from inside the `Catalog` entity to the `CatalogPublishAction` (message) level — decouples transmission instructions from catalog data
- Refactored from a single object to an **array** keyed by `catalogId`, supporting batch-published catalogs with per-catalog directives
- Added `variant` property to `resourceDirectives` (type, id, label) for localized pricing and entity overrides
- Changed `updateMode` default from `FULL` to `MERGE`
- Removed deprecation notices; `publishDirectives` is officially supported

### Push API (`/catalog/push`) — NEW
- Fire-and-forget delivery of a catalog to a specific downstream participant
- Distinct from `/catalog/publish` which submits for network-wide indexing

### Pull API (`/catalog/pull`) — OVERHAULED
- `filters` is now **required** with `additionalProperties: false` and `minProperties: 1` — unscoped pulls rejected at the schema boundary
- Moved `catalogIds` into `filters` (next to `networkIds`/`schemaTypes`)
- Added `minItems: 1` on each filter array; added `offset` pagination field

### Pull Callback (`/on_catalog_pull`) — NEW
- Replaced the `GET /catalog/pull/result/{requestId}/{filename}` download endpoint with an async `POST /on_catalog_pull` callback
- New `CatalogPullCallbackAction` schema: `requestId`, `status` (COMPLETED/FAILED), `catalogs` (inline), `objectUrl` (pre-signed download), `pagination`, `error`
- Documented at-least-once delivery semantics and BAP deduplication contract

### Subscription APIs — CLEANED
- Rewrote all subscription endpoint descriptions for clarity
- Added `403 Forbidden` (`NackForbidden`) response to subscription GET and DELETE for ownership enforcement
- Added descriptions to list, get, and delete endpoints

### Master Resource Search — IMPROVED
- Added clean descriptions to all three master endpoints (search, schemaTypes, get-by-id)

### Action values — STRICT
- Removed underscore action variants (`catalog_publish`, `on_catalog_publish`) — only slash-style actions are valid (`catalog/publish`, `catalog/on_publish`)
- Changed from `enum` to `const` for single-value action fields

### General
- Removed internal implementation details from all tag and endpoint descriptions
- Removed the unused "Catalog Distribution" tag
- Removed `additionalProperties: false` from `CatalogPublishAction` for extensibility

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)