### PR TITLE
Add AckSignature as third signature type; update NFH-004 §3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .cursor/*
 TODOs.md
+scripts/

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -1944,22 +1944,18 @@ components:
       schema:
         $ref: '#/components/schemas/CallbackSignature'
   headers:
-    SignatureHeader:
-      description: "Beckn HTTP Signature authentication header transmitted on every\
-        \ synchronous response. The signer is the responding actor (BPP or BAP); the\
-        \ receiver verifies it to confirm authenticated receipt of the response body.\n\
-        \nFormat follows the same draft-cavage-http-signatures-12 profile used for\
-        \ the Authorization request header, except the headers attribute covers only\
-        \ the standard three components: `(created) (expires) digest`. The digest\
-        \ covers the response body using BLAKE2b-512.\n\nSee NFH-004 Authentication\
-        \ and Trust for the full signing-string specification."
+    AckSignatureHeader:
+      description: "Beckn HTTP Ack Signature response header transmitted on every\
+        \ synchronous response. The signer is the responding NP (BPP or BAP); the\
+        \ receiver verifies it to confirm authenticated receipt. The signing string\
+        \ chains the responder's signature to the incoming request's Authorization\
+        \ signature via the `request-signature` field, cryptographically proving the\
+        \ responder was in possession of the specific inbound request.\n\nSee `#/components/schemas/AckSignature`\
+        \ for the wire format and signing string construction. See NFH-004 Authentication\
+        \ and Trust §5 for the full signing procedure."
       required: true
       schema:
-        type: string
-        pattern: ^Signature keyId="[^"]+",algorithm="ed25519",created="\d+",expires="\d+",headers="\(created\)
-          \(expires\) digest",signature="[A-Za-z0-9+/]+=*"$
-        example: 'Signature keyId="example.ns/gro.example/key-001|ed25519",algorithm="ed25519",created="1714000000",expires="1714000600",headers="(created)
-          (expires) digest",signature="BASE64SIGNATURE=="'
+        $ref: '#/components/schemas/AckSignature'
   schemas:
     CancelAction:
       title: Cancel Action
@@ -3668,9 +3664,8 @@ components:
         \ The receiving actor verifies it against the sender's registered public key.\
         \ Requests with an absent, expired, or unverifiable Signature MUST be rejected\
         \ with 401 NackUnauthorized.\n\nFor BPP solicited callbacks, use CallbackSignature\
-        \ instead. For synchronous response signing, see the Signature response header\
-        \ (components/headers/SignatureHeader). See NFH-004 Authentication and Trust\
-        \ for the full specification."
+        \ instead. For synchronous response signing, see components/headers/AckSignatureHeader.\
+        \ See NFH-004 Authentication and Trust for the full specification."
       type: string
       pattern: ^Signature keyId="[^"]+",algorithm="ed25519",created="\d+",expires="\d+",headers="\(created\)
         \(expires\) digest",signature="[A-Za-z0-9+/]+=*"$
@@ -3695,13 +3690,38 @@ components:
         \ The algorithm MUST be `ed25519`. The body digest covers the callback body\
         \ using BLAKE2b-512.\n\nUsed for: BPP→BAP solicited callbacks only. For provider-initiated\
         \ notifications (no preceding BAP request), use the standard Signature schema\
-        \ instead. For synchronous response signing, see components/headers/SignatureHeader.\
-        \ See NFH-004 Authentication and Trust §5 for the full callback signing procedure."
+        \ instead. For synchronous response signing, see components/headers/AckSignatureHeader.\
+        \ See NFH-004 Authentication and Trust §6 for the full callback signing procedure."
       type: string
       pattern: ^Signature keyId="[^"]+",algorithm="ed25519",created="\d+",expires="\d+",headers="\(created\)
         \(expires\) digest request-signature",signature="[A-Za-z0-9+/]+=*"$
       example: 'Signature keyId="example.ns/gro.example/bpp-key-001|ed25519",algorithm="ed25519",created="1714000060",expires="1714000660",headers="(created)
         (expires) digest request-signature",signature="BPPSIGNATURE=="'
+
+    AckSignature:
+      title: Beckn HTTP Ack Signature
+      description: "A digitally signed authentication credential transmitted in the\
+        \ HTTP `Signature` response header on every synchronous Beckn response, proving\
+        \ that the responding NP received and authenticated the specific inbound request.\n\
+        \nThe responding actor produces this by signing a four-line canonical signing\
+        \ string with its Ed25519 private key:\n\n    (created): {unix_timestamp}\n\
+        \    (expires): {unix_timestamp}\n    digest: BLAKE2b-512={base64_response_body_hash}\n\
+        \    request-signature: {incoming_request_raw_base64_signature}\n\nThe fourth\
+        \ line (`request-signature`) contains the raw Base64 Ed25519 signature value\
+        \ extracted verbatim from the `signature=\"...\"` field of the incoming request's\
+        \ `Authorization` header. This binds the Ack cryptographically to the specific\
+        \ signed request that triggered it.\n\nThe `headers` attribute MUST be `\"(created)\
+        \ (expires) digest request-signature\"`. The `keyId` identifies the responding\
+        \ NP. The algorithm MUST be `ed25519`. The body digest covers the response\
+        \ body using BLAKE2b-512.\n\nUsed for: all synchronous HTTP responses across\
+        \ all Beckn endpoints. For request signing, see Signature. For BPP solicited\
+        \ callback signing, see CallbackSignature. See NFH-004 Authentication and\
+        \ Trust §5 for the full response signing procedure."
+      type: string
+      pattern: ^Signature keyId="[^"]+",algorithm="ed25519",created="\d+",expires="\d+",headers="\(created\)
+        \(expires\) digest request-signature",signature="[A-Za-z0-9+/]+=*"$
+      example: 'Signature keyId="example.ns/gro.example/bpp-key-001|ed25519",algorithm="ed25519",created="1714000060",expires="1714000660",headers="(created)
+        (expires) digest request-signature",signature="ACKSIGNATURE=="'
 
     Support:
       description: "A structured record representing a consumer's request for assistance\
@@ -4501,7 +4521,7 @@ components:
         \ implementer's authenticated receipt."
       headers:
         Signature:
-          $ref: '#/components/headers/SignatureHeader'
+          $ref: '#/components/headers/AckSignatureHeader'
       content:
         application/json:
           schema:
@@ -4513,7 +4533,7 @@ components:
         \ an Error explaining why no callback will follow."
       headers:
         Signature:
-          $ref: '#/components/headers/SignatureHeader'
+          $ref: '#/components/headers/AckSignatureHeader'
       content:
         application/json:
           schema:
@@ -4524,7 +4544,7 @@ components:
         \ process the request further. The caller MUST correct the request before retrying."
       headers:
         Signature:
-          $ref: '#/components/headers/SignatureHeader'
+          $ref: '#/components/headers/AckSignatureHeader'
       content:
         application/json:
           schema:
@@ -4536,7 +4556,7 @@ components:
         \ caller MUST correct its signing credential or key registration before retrying."
       headers:
         Signature:
-          $ref: '#/components/headers/SignatureHeader'
+          $ref: '#/components/headers/AckSignatureHeader'
       content:
         application/json:
           schema:
@@ -4548,7 +4568,7 @@ components:
         \ error object with additional diagnostic detail."
       headers:
         Signature:
-          $ref: '#/components/headers/SignatureHeader'
+          $ref: '#/components/headers/AckSignatureHeader'
       content:
         application/json:
           schema:
@@ -4561,7 +4581,7 @@ components:
         \ discretionary NACKs per CON-008-20."
       headers:
         Signature:
-          $ref: '#/components/headers/SignatureHeader'
+          $ref: '#/components/headers/AckSignatureHeader'
       content:
         application/json:
           schema:
@@ -4572,7 +4592,7 @@ components:
         \ Retry-After header indicating when the caller MAY retry."
       headers:
         Signature:
-          $ref: '#/components/headers/SignatureHeader'
+          $ref: '#/components/headers/AckSignatureHeader'
         Retry-After:
           description: "Number of seconds (integer) or HTTP-date after which the\
             \ caller MAY retry the request."

--- a/docs/Authentication_and_Trust.md
+++ b/docs/Authentication_and_Trust.md
@@ -45,6 +45,7 @@ This document defines the authentication and trust model for Beckn Protocol v2.0
         - [3.1 Body Digest](#31-body-digest)
         - [3.2 Standard Signing String](#32-standard-signing-string)
         - [3.3 Callback Signing String](#33-callback-signing-string)
+        - [3.4 Ack Response Signing String](#34-ack-response-signing-string)
       - [4. Request Signing — BAP and BPP](#4-request-signing--bap-and-bpp)
       - [5. Synchronous Response Signing](#5-synchronous-response-signing)
       - [6. Callback Signing — BPP to BAP](#6-callback-signing--bpp-to-bap)
@@ -114,7 +115,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 - **keyId:** A structured string that uniquely identifies a signing key registered on a dedi-protocol registry.
 - **Signing string:** The canonical byte sequence that is signed and verified using Ed25519.
 - **Body digest:** The BLAKE2b-512 hash of the HTTP request or response body, encoded as described in §3.1.
-- **request-signature:** The raw Ed25519 signature value extracted from a BAP's `Authorization` header and included verbatim in a BPP's callback signing string to chain the two message legs together.
+- **request-signature:** The raw Ed25519 signature value extracted from an incoming request's `Authorization` header and included verbatim in either a BPP's callback signing string (§3.3) or a responding NP's Ack response signing string (§3.4), cryptographically binding the outgoing message to the specific request that triggered it.
 - **Implicit keyId:** A keyId that uses a path-only format and is resolved exclusively via the GRR at `fabric.nfh.global/registry`.
 - **Explicit keyId:** A keyId that embeds the full registry URL, allowing resolution against any dedi-protocol compliant registry.
 - **Provider-initiated notification:** A callback sent by a BPP to a BAP's `/on_*` endpoint without a preceding BAP request in the current message exchange. Only endpoints designated as supporting provider-initiated notifications in the Beckn Protocol API specification may send them.
@@ -251,6 +252,22 @@ request-signature: {bap_signature_value}
 
 The `headers` attribute of the BPP's callback `Authorization` header MUST declare all four fields in order: `"(created) (expires) digest request-signature"`.
 
+##### 3.4 Ack Response Signing String
+
+Used for every synchronous HTTP response. The responding NP MUST append a fourth line containing the incoming request's signature:
+
+```
+(created): {created_unix_ts}
+(expires): {expires_unix_ts}
+digest: {response_body_digest}
+request-signature: {incoming_request_signature_value}
+```
+
+- `{response_body_digest}` — digest of the **response** body (not the inbound request body).
+- `{incoming_request_signature_value}` — the raw Base64-encoded Ed25519 signature value extracted from the incoming request's `Authorization` header's `signature="..."` field. This MUST be the literal string value of the `signature` attribute only, without the surrounding quotes or any other Authorization header components. Extraction procedure is identical to §3.3.
+
+The `headers` attribute of the `Signature` response header MUST declare all four fields in order: `"(created) (expires) digest request-signature"`.
+
 #### 4. Request Signing — BAP and BPP
 
 Every Beckn HTTP request — whether initiated by a BAP (to a BPP or DS) or by a BPP (callback to a BAP) — MUST carry an `Authorization` header in the following format:
@@ -267,7 +284,7 @@ Attribute definitions:
 | `algorithm` | string | MUST be `ed25519`. |
 | `created` | integer string | Unix timestamp of signature creation. |
 | `expires` | integer string | Unix timestamp of signature expiry. |
-| `headers` | string | Space-separated list of fields included in the signing string. For BAP requests and provider-initiated notifications: `"(created) (expires) digest"`. For BPP solicited callbacks: `"(created) (expires) digest request-signature"`. |
+| `headers` | string | Space-separated list of fields included in the signing string. For BAP requests and provider-initiated notifications: `"(created) (expires) digest"`. For BPP solicited callbacks: `"(created) (expires) digest request-signature"`. For synchronous responses (`Signature` header): `"(created) (expires) digest request-signature"`. |
 | `signature` | string | Standard Base64 encoding of the Ed25519 signature over the signing string. |
 
 The signing procedure for a request is:
@@ -281,29 +298,30 @@ The signing procedure for a request is:
 
 #### 5. Synchronous Response Signing
 
-Every synchronous HTTP response — regardless of status code (200, 400, 401, 409, 429, 500) — MUST carry a `Signature` response header. This header proves that the responding NP authenticated, received, and processed the request, establishing non-repudiation for the synchronous leg.
+Every synchronous HTTP response — regardless of status code (200, 400, 401, 409, 429, 500) — MUST carry a `Signature` response header. This header proves that the responding NP received and authenticated the specific inbound request, establishing non-repudiation for the synchronous leg.
 
 The `Signature` response header uses the same format as the request `Authorization` header but:
 
 - The header name is `Signature`, not `Authorization`.
 - The body digest is computed over the **response** body.
-- The signing string is the standard signing string (§3.2).
+- The signing string is the Ack response signing string (§3.4), which chains the response to the inbound request's signature via `request-signature`.
 - The signer is the responding NP (BPP or DS for incoming requests; BAP for incoming callbacks).
 
 ```
-Signature: keyId="{keyId}",algorithm="ed25519",created="{created}",expires="{expires}",headers="(created) (expires) digest",signature="{base64_signature}"
+Signature: keyId="{keyId}",algorithm="ed25519",created="{created}",expires="{expires}",headers="(created) (expires) digest request-signature",signature="{base64_signature}"
 ```
 
 The signing procedure for a synchronous response is:
 
 1. Serialize the response body to UTF-8.
 2. Compute the body digest (§3.1).
-3. Construct the standard signing string (§3.2).
-4. Sign the UTF-8 encoding of the signing string using the responding NP's Ed25519 private key.
-5. Base64-encode the 64-byte signature.
-6. Add the `Signature` header to the HTTP response.
+3. Extract the raw Base64 signature value from the incoming request's `Authorization` header `signature="..."` field.
+4. Construct the Ack response signing string (§3.4).
+5. Sign the UTF-8 encoding of the signing string using the responding NP's Ed25519 private key.
+6. Base64-encode the 64-byte signature.
+7. Add the `Signature` header to the HTTP response.
 
-The sending NP SHOULD verify the `Signature` response header upon receiving a synchronous response, using the responding NP's public key fetched via the key lookup procedure (§2.3). A missing or invalid `Signature` response header does not invalidate the transaction but SHOULD be logged and MAY be treated as a degraded trust signal.
+The sending NP SHOULD verify the `Signature` response header upon receiving a synchronous response, using the responding NP's public key fetched via the key lookup procedure (§2.3). The sender SHOULD confirm the `request-signature` field in the response matches the `signature` value from its own outbound `Authorization` header for that request. A missing or invalid `Signature` response header does not invalidate the transaction but SHOULD be logged and MAY be treated as a degraded trust signal.
 
 #### 6. Callback Signing — BPP to BAP
 
@@ -375,7 +393,7 @@ Upon receiving a request from a BAP, the BPP or DS MUST perform the following ve
 4. Fetch the BAP's public key using the key lookup procedure (§2.3).
 5. Reconstruct the standard signing string (§3.2) using the `created` and `expires` values and the BLAKE2b-512 digest of the received request body.
 6. Verify the decoded `signature` against the signing string using the BAP's public key.
-7. Return `200 Ack` with the responding NP's `Signature` response header (§5), or the appropriate error response.
+7. Return the appropriate response with the responding NP's `Signature` response header (§5). The `Signature` header MUST use the Ack response signing string (§3.4), with the `request-signature` field set to the raw Base64 value extracted from the incoming request's `Authorization` header.
 
 #### 9. Pre-call NP Verification
 
@@ -442,6 +460,7 @@ A BPP sending a provider-initiated notification MUST assign a unique `messageId`
 | CON-004-20 | A BPP provider-initiated notification MUST carry a `transactionId` matching an active, confirmed transaction between that BAP and BPP. | MUST |
 | CON-004-21 | When both the sending and receiving NP are members of the same subnet, the sending NP SHOULD perform a `subscriber_reference` registry lookup for the receiving NP immediately before dispatching a message. | SHOULD |
 | CON-004-22 | A BPP SHOULD verify that its own signing key has not expired before sending a solicited callback. | SHOULD |
+| CON-004-23 | Every synchronous response `Signature` header MUST use the Ack response signing string (§3.4) with `headers="(created) (expires) digest request-signature"`. The `request-signature` value MUST be the raw Base64 `signature` attribute value from the incoming request's `Authorization` header. | MUST |
 
 ### Cross-cutting considerations
 
@@ -472,7 +491,7 @@ The following v1.x patterns are breaking changes in v2.0:
 1. **BG removed:** There is no `X-Gateway-Authorization` header in v2.0. BG routing infrastructure MUST be decommissioned or bypassed. Direct BAP ↔ BPP/DS connectivity is required.
 2. **Registry protocol change:** The v1.x Beckn Protocol-compliant registry lookup is replaced by dedi protocol-compliant lookup against `fabric.nfh.global/registry`. All registry query code MUST be updated to the dedi protocol API.
 3. **Request-signature chaining:** Solicited callbacks now carry the BAP's original signature as the `request-signature` field in the signing string. v1.x callback implementations MUST add this field with `headers="(created) (expires) digest request-signature"`.
-4. **Synchronous response signing:** Every response now requires a `Signature` header. v1.x implementations that returned unsigned responses MUST add this.
+4. **Synchronous response signing:** Every response now requires a `Signature` header using the Ack response signing string (§3.4), which includes `request-signature`. v1.x implementations that returned unsigned responses MUST add this; implementations that used a 3-line signing string for responses MUST add the `request-signature` field.
 5. **keyId format change:** The v1.x format `{subscriber_id}|{unique_key_id}|{algorithm}` is replaced by the path-based implicit format `{namespace_id}/{registry_id}/{record_id}|{algorithm}`. Existing key registrations MUST be migrated to the new namespace structure in the GRR before go-live on v2.0.
 
 ### Examples
@@ -511,17 +530,44 @@ Content-Type: application/json
 
 #### Example 2: BPP Synchronous Ack Response
 
-**Scenario:** BPP receives the `/select` request, verifies it, and returns a synchronous `200 Ack`.
+**Scenario:** BPP receives the `/select` request from Example 1, verifies it, and returns a synchronous `200 Ack`.
+
+##### Step 1 — Extract BAP's request signature
+
+```
+bap_signature_value = "Base64EncodedEd25519SignatureHere=="
+```
+
+This is the raw Base64 value from the `signature="..."` field of the BAP's `Authorization` header in Example 1.
+
+##### Step 2 — Compute Ack body digest
+
+```
+ack_body = '{"message":{"status":"ACK","messageId":"550e8400-e29b-41d4-a716-446655440000"}}'
+digest = "BLAKE2b-512=" + Base64( BLAKE2b-512( UTF-8(ack_body) ) )
+       = "BLAKE2b-512=AckBodyDigestHere..."
+```
+
+##### Step 3 — Construct Ack signing string
+
+```
+(created): 1746518401
+(expires): 1746518701
+digest: BLAKE2b-512=AckBodyDigestHere...
+request-signature: Base64EncodedEd25519SignatureHere==
+```
+
+##### Step 4 — Assemble Ack response
 
 ```http
 HTTP/1.1 200 OK
 Content-Type: application/json
-Signature: keyId="bpp.example.com/keys/k002|ed25519",algorithm="ed25519",created="1746518401",expires="1746518701",headers="(created) (expires) digest",signature="BPPSignatureOverAckBodyHere=="
+Signature: keyId="bpp.example.com/keys/k002|ed25519",algorithm="ed25519",created="1746518401",expires="1746518701",headers="(created) (expires) digest request-signature",signature="BPPAckSignatureHere=="
 
 {"message":{"status":"ACK","messageId":"550e8400-e29b-41d4-a716-446655440000"}}
 ```
 
-The BPP's `Signature` header signs the `{"message":{"status":"ACK","messageId":"550e8400-e29b-41d4-a716-446655440000"}}` body using the BPP's Ed25519 private key. The `messageId` echoes the `messageId` from the originating `/select` request's `context` object.
+The BPP's `Signature` header signs a four-line string that covers the Ack body digest and the BAP's original request signature. The BAP verifies the BPP's `Signature` and confirms the `request-signature` field matches the `signature` value it sent in its own `Authorization` header.
 
 #### Example 3: BPP Solicited Callback to BAP
 


### PR DESCRIPTION
## Summary

This PR formalises the three Beckn signature types and closes the non-repudiation gap on synchronous Ack responses.

**Three signature types:**

| Type | Header | Signing string |
|---|---|---|
| `Signature` (RequestAuth) | `Authorization` request header | 3-line: `(created) (expires) digest` |
| `CallbackSignature` (CallbackAuth) | `Authorization` request header | 4-line: `(created) (expires) digest request-signature` |
| `AckSignature` *(new)* | `Signature` response header | 4-line: `(created) (expires) digest request-signature` |

`AckSignature` chains the synchronous response to the inbound request's Authorization signature, proving the responder was in possession of the specific signed request. Without this, a responding NP could deny having received and acknowledged a request.

## Changes

**`api/v2.0.0/beckn.yaml`**
- Add `AckSignature` schema (4-line pattern with `request-signature`)
- Rename `SignatureHeader` → `AckSignatureHeader`, reference `AckSignature` schema
- Update all response definitions to reference `AckSignatureHeader`

**`docs/Authentication_and_Trust.md`** (NFH-004)
- Add §3.4 Ack Response Signing String
- Update §5 Synchronous Response Signing to use §3.4
- Update §8 to require `request-signature` in the response `Signature` header
- Add `CON-004-23` conformance requirement
- Update Example 2 with full 4-step Ack signing walkthrough
- Update `request-signature` definition and §4 headers table
- Update Migration Notes