### PR TITLE
fix(Consideration): make status optional and constrain code enum (#154)

### DIFF
--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -2116,21 +2116,11 @@ components:
         status:
           description: >
             The lifecycle state of this consideration. Required when Consideration
-            appears in Contract.consideration[] from on_select onward
-            (PENDING → QUOTED → ACTIVE → CANCELLED). Optional in Offer.considerations[]
+            appears in Contract.consideration[] from on_select onward. Optional in Offer.considerations[]
             (catalog context, where no transaction lifecycle has been established) and
             in select-phase payloads where the Seeker NP signals intent before the
             Provider NP has priced the consideration.
-          allOf:
-            - $ref: '#/components/schemas/Descriptor'
-            - type: object
-              properties:
-                code:
-                  enum:
-                    - PENDING
-                    - QUOTED
-                    - ACTIVE
-                    - CANCELLED
+          $ref: '#/components/schemas/Descriptor'
         considerationAttributes:
           description: 'Domain-specific attributes of this consideration. For monetary considerations,
 

--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -2096,7 +2096,6 @@ components:
       type: object
       description: 'Generalized representation of value exchanged under a Contract.
 
-
         Consideration is domain-neutral and may represent:
 
         - Monetary value
@@ -2110,14 +2109,28 @@ components:
         - Compliance artifact'
       required:
       - id
-      - status
       properties:
         id:
           description: Identifier of this consideration
           type: string
         status:
-          description: The status of this consideration
-          $ref: '#/components/schemas/Descriptor'
+          description: >
+            The lifecycle state of this consideration. Required when Consideration
+            appears in Contract.consideration[] from on_select onward
+            (PENDING → QUOTED → ACTIVE → CANCELLED). Optional in Offer.considerations[]
+            (catalog context, where no transaction lifecycle has been established) and
+            in select-phase payloads where the Seeker NP signals intent before the
+            Provider NP has priced the consideration.
+          allOf:
+            - $ref: '#/components/schemas/Descriptor'
+            - type: object
+              properties:
+                code:
+                  enum:
+                    - PENDING
+                    - QUOTED
+                    - ACTIVE
+                    - CANCELLED
         considerationAttributes:
           description: 'Domain-specific attributes of this consideration. For monetary considerations,
 


### PR DESCRIPTION
- Remove status from Consideration.required (was: [id, status], now: [id])
- Add allOf enum constraint on status.code: PENDING | QUOTED | ACTIVE | CANCELLED
- Mirrors the existing Contract.status pattern in the same spec
- Backward compatible: constraint relaxation only; all existing valid payloads unaffected

Fixes[ #154](https://github.com/beckn/protocol-specifications-v2/issues/154)