### PR TITLE
Fix invalid default for SpatialConstraint.quantifier

### DIFF
--- a/api/v2.0.0/beckn.yaml
+++ b/api/v2.0.0/beckn.yaml
@@ -3996,7 +3996,7 @@ components:
           - ANY
           - ALL
           - NONE
-          default: any
+          default: ANY
         srid:
           description: Coordinate Reference System identifier for `geometry`. Default is `"EPSG:4326"`. If provided, servers MAY reproject to EPSG:4326 internally.
           type: string


### PR DESCRIPTION
The `default` was `any` (lowercase) but the enum only permits `ANY`/`ALL`/`NONE`, making the default invalid against its own schema. Corrected to `ANY` to match the documented behavior ("at least one element matches (default)").

Closes #173 